### PR TITLE
Add support for SNI

### DIFF
--- a/manifests/manage_binding.pp
+++ b/manifests/manage_binding.pp
@@ -1,5 +1,5 @@
 #
-define iis::manage_binding($site_name, $protocol, $port, $host_header = '', $ip_address = '*', $certificate_thumbprint = '', $ensure = 'present', $require_site = true) {
+define iis::manage_binding($site_name, $protocol, $port, $host_header = '', $ip_address = '*', $certificate_thumbprint = '', $store = 'My', $sslFlag = 0, $ensure = 'present', $require_site = true) {
   if ! ($protocol in [ 'http', 'https', 'net.tcp', 'net.pipe', 'netmsmq', 'msmq.formatname' ]) {
     fail('valid protocols \'http\', \'https\', \'net.tcp\', \'net.pipe\', \'netmsmq\', \'msmq.formatname\'')
   }
@@ -7,6 +7,7 @@ define iis::manage_binding($site_name, $protocol, $port, $host_header = '', $ip_
   validate_string($site_name)
   validate_re($site_name,['^(.)+$'], 'site_name must not be empty')
   validate_re($ensure, '^(present|installed|absent|purged)$', 'ensure must be one of \'present\', \'installed\', \'absent\', \'purged\'')
+  validate_re($store, '^(My|WebHosting)$')
   validate_bool($require_site)
   if ! ($ip_address == '*') {
     validate_re($ip_address, ['^([0-9]){1,3}\.([0-9]){1,3}\.([0-9]){1,3}\.([0-9]){1,3}$'], "\"${ip_address}\" is not a valid ip address")
@@ -19,7 +20,7 @@ define iis::manage_binding($site_name, $protocol, $port, $host_header = '', $ip_
     }
 
     exec { "CreateBinding-${title}":
-      command   => "Import-Module WebAdministration; New-WebBinding -Name \"${site_name}\" -Port ${port} -Protocol \"${protocol}\" -HostHeader \"${host_header}\" -IPAddress \"${ip_address}\"",
+      command   => "Import-Module WebAdministration; New-WebBinding -Name \"${site_name}\" -Port ${port} -Protocol \"${protocol}\" -HostHeader \"${host_header}\" -IPAddress \"${ip_address}\" -SslFlags \"${sslFlag}\"",
       onlyif    => "Import-Module WebAdministration; if (Get-WebBinding -Name \"${site_name}\" -Port ${port} -Protocol \"${protocol}\" -HostHeader \"${host_header}\" -IPAddress \"${ip_address}\" | Where-Object {\$_.bindingInformation -eq \"${ip_address}:${port}:${host_header}\"}) { exit 1 } else { exit 0 }",
       provider  => powershell,
       logoutput => true,
@@ -54,7 +55,7 @@ define iis::manage_binding($site_name, $protocol, $port, $host_header = '', $ip_
     }
   } else {
     exec { "DeleteBinding-${title}":
-    command   => "Import-Module WebAdministration; Remove-WebBinding -Name \"${site_name}\" -Port ${port} -Protocol \"${protocol}\" -HostHeader \"${host_header}\" -IPAddress \"${ip_address}\"",
+    command   => "Import-Module WebAdministration; Remove-WebBinding -Name \"${site_name}\" -Port ${port} -Protocol \"${protocol}\" -HostHeader \"${host_header}\" -IPAddress \"${ip_address}\" -SslFlags \"${sslFlag}\"",
     onlyif    => "Import-Module WebAdministration; if (!(Get-WebBinding -Name \"${site_name}\" -Port ${port} -Protocol \"${protocol}\" -HostHeader \"${host_header}\" -IPAddress \"${ip_address}\" | Where-Object {\$_.bindingInformation -eq \"${ip_address}:${port}:${host_header}\"})) { exit 1 } else { exit 0 }",
     provider  => powershell,
     logoutput => true,

--- a/spec/defines/manage_binding_spec.rb
+++ b/spec/defines/manage_binding_spec.rb
@@ -13,7 +13,7 @@ describe 'iis::manage_binding', :type => :define do
     } }
 
     it { should contain_exec('CreateBinding-myWebSite-port-80').with({
-      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\"",
+      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags 0",
       'onlyif'  => "Import-Module WebAdministration; if (Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" | Where-Object {\$_.bindingInformation -eq \"*:80:myHost.example.com\"}) { exit 1 } else { exit 0 }",
       'require' => 'Iis::Manage_site[myWebSite]',
     })}
@@ -30,7 +30,7 @@ describe 'iis::manage_binding', :type => :define do
     } }
 
     it { should contain_exec('CreateBinding-myWebSite-port-80').with({
-      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"192.168.1.5\"",
+      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"192.168.1.5\" -SslFlags 0",
       'onlyif'  => "Import-Module WebAdministration; if (Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"192.168.1.5\" | Where-Object {\$_.bindingInformation -eq \"192.168.1.5:80:myHost.example.com\"}) { exit 1 } else { exit 0 }",
       'require' => 'Iis::Manage_site[myWebSite]',
     })}
@@ -139,7 +139,7 @@ describe 'iis::manage_binding', :type => :define do
     } }
 
     it { should contain_exec('CreateBinding-myWebSite-port-80').with({
-      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\"",
+      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags 0",
       'onlyif'  => "Import-Module WebAdministration; if (Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" | Where-Object {\$_.bindingInformation -eq \"*:80:myHost.example.com\"}) { exit 1 } else { exit 0 }",
     })}
   end
@@ -155,7 +155,7 @@ describe 'iis::manage_binding', :type => :define do
     } }
 
     it { should contain_exec('CreateBinding-myWebSite-port-80').with({
-      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\"",
+      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags 0",
       'onlyif'  => "Import-Module WebAdministration; if (Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" | Where-Object {\$_.bindingInformation -eq \"*:80:myHost.example.com\"}) { exit 1 } else { exit 0 }",
       'require' => 'Iis::Manage_site[myWebSite]',
     })}
@@ -172,7 +172,7 @@ describe 'iis::manage_binding', :type => :define do
     } }
 
     it { should contain_exec('DeleteBinding-myWebSite-port-80').with({
-      'command' => "Import-Module WebAdministration; Remove-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\"",
+      'command' => "Import-Module WebAdministration; Remove-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags 0",
       'onlyif'  => "Import-Module WebAdministration; if (!(Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" | Where-Object {\$_.bindingInformation -eq \"*:80:myHost.example.com\"})) { exit 1 } else { exit 0 }",
     })}
 
@@ -190,7 +190,7 @@ describe 'iis::manage_binding', :type => :define do
     } }
 
     it { should contain_exec('DeleteBinding-myWebSite-port-80').with({
-      'command' => "Import-Module WebAdministration; Remove-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\"",
+      'command' => "Import-Module WebAdministration; Remove-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags 0",
       'onlyif'  => "Import-Module WebAdministration; if (!(Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" | Where-Object {\$_.bindingInformation -eq \"*:80:myHost.example.com\"})) { exit 1 } else { exit 0 }",
     })}
 
@@ -208,7 +208,7 @@ describe 'iis::manage_binding', :type => :define do
     }}
 
     it { should contain_exec('CreateBinding-myWebSite-port-80').with({
-        'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\"",
+        'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags 0",
         'onlyif'  => "Import-Module WebAdministration; if (Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" | Where-Object {\$_.bindingInformation -eq \"*:80:myHost.example.com\"}) { exit 1 } else { exit 0 }",
         'require' => nil,
       })

--- a/spec/defines/manage_binding_spec.rb
+++ b/spec/defines/manage_binding_spec.rb
@@ -13,7 +13,7 @@ describe 'iis::manage_binding', :type => :define do
     } }
 
     it { should contain_exec('CreateBinding-myWebSite-port-80').with({
-      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags 0",
+      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags \"0\"",
       'onlyif'  => "Import-Module WebAdministration; if (Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" | Where-Object {\$_.bindingInformation -eq \"*:80:myHost.example.com\"}) { exit 1 } else { exit 0 }",
       'require' => 'Iis::Manage_site[myWebSite]',
     })}
@@ -30,7 +30,7 @@ describe 'iis::manage_binding', :type => :define do
     } }
 
     it { should contain_exec('CreateBinding-myWebSite-port-80').with({
-      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"192.168.1.5\" -SslFlags 0",
+      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"192.168.1.5\" -SslFlags \"0\"",
       'onlyif'  => "Import-Module WebAdministration; if (Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"192.168.1.5\" | Where-Object {\$_.bindingInformation -eq \"192.168.1.5:80:myHost.example.com\"}) { exit 1 } else { exit 0 }",
       'require' => 'Iis::Manage_site[myWebSite]',
     })}
@@ -139,7 +139,7 @@ describe 'iis::manage_binding', :type => :define do
     } }
 
     it { should contain_exec('CreateBinding-myWebSite-port-80').with({
-      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags 0",
+      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags \"0\"",
       'onlyif'  => "Import-Module WebAdministration; if (Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" | Where-Object {\$_.bindingInformation -eq \"*:80:myHost.example.com\"}) { exit 1 } else { exit 0 }",
     })}
   end
@@ -155,7 +155,7 @@ describe 'iis::manage_binding', :type => :define do
     } }
 
     it { should contain_exec('CreateBinding-myWebSite-port-80').with({
-      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags 0",
+      'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags \"0\"",
       'onlyif'  => "Import-Module WebAdministration; if (Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" | Where-Object {\$_.bindingInformation -eq \"*:80:myHost.example.com\"}) { exit 1 } else { exit 0 }",
       'require' => 'Iis::Manage_site[myWebSite]',
     })}
@@ -172,7 +172,7 @@ describe 'iis::manage_binding', :type => :define do
     } }
 
     it { should contain_exec('DeleteBinding-myWebSite-port-80').with({
-      'command' => "Import-Module WebAdministration; Remove-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags 0",
+      'command' => "Import-Module WebAdministration; Remove-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags \"0\"",
       'onlyif'  => "Import-Module WebAdministration; if (!(Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" | Where-Object {\$_.bindingInformation -eq \"*:80:myHost.example.com\"})) { exit 1 } else { exit 0 }",
     })}
 
@@ -190,7 +190,7 @@ describe 'iis::manage_binding', :type => :define do
     } }
 
     it { should contain_exec('DeleteBinding-myWebSite-port-80').with({
-      'command' => "Import-Module WebAdministration; Remove-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags 0",
+      'command' => "Import-Module WebAdministration; Remove-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags \"0\"",
       'onlyif'  => "Import-Module WebAdministration; if (!(Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" | Where-Object {\$_.bindingInformation -eq \"*:80:myHost.example.com\"})) { exit 1 } else { exit 0 }",
     })}
 
@@ -208,7 +208,7 @@ describe 'iis::manage_binding', :type => :define do
     }}
 
     it { should contain_exec('CreateBinding-myWebSite-port-80').with({
-        'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags 0",
+        'command' => "Import-Module WebAdministration; New-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" -SslFlags \"0\"",
         'onlyif'  => "Import-Module WebAdministration; if (Get-WebBinding -Name \"myWebSite\" -Port 80 -Protocol \"http\" -HostHeader \"myHost.example.com\" -IPAddress \"*\" | Where-Object {\$_.bindingInformation -eq \"*:80:myHost.example.com\"}) { exit 1 } else { exit 0 }",
         'require' => nil,
       })

--- a/templates/create-certificate-binding.ps1.erb
+++ b/templates/create-certificate-binding.ps1.erb
@@ -1,22 +1,45 @@
 Import-Module WebAdministration
 
 $site = Get-Website | Where-Object { $_.Name -eq "<%= @site_name %>" }
+$store = "<%= @store %>"
+$sslFlag = "<%= @sslFlag %>"
 $certsAttachedToSite = Get-ChildItem IIS:\SSLBindings | ? { $site | Select-Object { $_ -contains $_.Sites.Value }} | % { $_.Thumbprint }
-$certificate = Get-ChildItem CERT:\LocalMachine\My | ? { $certsAttachedToSite -contains $_.Thumbprint} | Where-Object { $_.Thumbprint -eq "<%= @certificate_thumbprint %>" }
+$certificate = Get-ChildItem CERT:\LocalMachine\$store | ? { $certsAttachedToSite -contains $_.Thumbprint} | Where-Object { $_.Thumbprint -eq "<%= @certificate_thumbprint %>" }
 
-if((Test-Path IIS:\SslBindings\<%= @ip_address %>!<%= @port %>) -eq $false) {
-    push-location IIS:\SslBindings
-    Get-Item Cert:\LocalMachine\My\<%= @certificate_thumbprint %> | New-Item <%= @ip_address %>!<%= @port %>
-}
-elseif (((Test-Path IIS:\SslBindings\<%= @ip_address %>!<%= @port %>) -eq $true) -and (($certificate -ne $null) -or ($certificate.Thumbprint -ne "<%= @certificate_thumbprint %>"))) {
-    push-location IIS:\SslBindings
-    Get-Item Cert:\LocalMachine\My\<%= @certificate_thumbprint %> | Set-Item <%= @ip_address %>!<%= @port %>
-    foreach ($cert in $certificates) {
-        if(($cert -ne $null) -and ($cert.Thumbprint -ne "<%= @certificate_thumbprint %>")) {
-            Get-Item Cert:\LocalMachine\My\$cert.Thumbprint | Remove-Item <%= @ip_address %>!<%= @port %>
+if(@(0,2) -contains $SslFlag) {
+    if((Test-Path IIS:\SslBindings\<%= @ip_address %>!<%= @port %>) -eq $false) {
+        push-location IIS:\SslBindings
+        Get-Item Cert:\LocalMachine\$store\<%= @certificate_thumbprint %> | New-Item <%= @ip_address %>!<%= @port %>
+    }
+    elseif (((Test-Path IIS:\SslBindings\<%= @ip_address %>!<%= @port %>) -eq $true) -and (($certificate -ne $null) -or ($certificate.Thumbprint -ne "<%= @certificate_thumbprint %>"))) {
+        push-location IIS:\SslBindings
+        Get-Item Cert:\LocalMachine\$store\<%= @certificate_thumbprint %> | Set-Item <%= @ip_address %>!<%= @port %>
+        foreach ($cert in $certificates) {
+            if(($cert -ne $null) -and ($cert.Thumbprint -ne "<%= @certificate_thumbprint %>")) {
+                Get-Item Cert:\LocalMachine\$store\$cert.Thumbprint | Remove-Item <%= @ip_address %>!<%= @port %>
+            }
         }
+    }
+    else {
+        exit 0
     }
 }
 else {
-    exit 0
+    if((Test-Path IIS:\SslBindings\<%= @ip_address %>!<%= @port %>!<%= @host_header %>) -eq $false) {
+        push-location IIS:\SslBindings
+        Get-Item Cert:\LocalMachine\$store\<%= @certificate_thumbprint %> | New-Item <%= @ip_address %>!<%= @port %>!<%= @host_header %> -SslFlags $sslFLag
+    }
+    elseif (((Test-Path IIS:\SslBindings\<%= @ip_address %>!<%= @port %>!<%= @host_header %>) -eq $true) -and (($certificate -ne $null) -or ($certificate.Thumbprint -ne "<%= @certificate_thumbprint %>"))) {
+        push-location IIS:\SslBindings
+        Remove-Item <%= @ip_address %>!<%= @port %>!<%= @host_header %>
+        Get-Item Cert:\LocalMachine\$store\<%= @certificate_thumbprint %> | New-Item <%= @ip_address %>!<%= @port %>!<%= @host_header %> -SslFlags $sslFLag
+        foreach ($cert in $certificates) {
+            if(($cert -ne $null) -and ($cert.Thumbprint -ne "<%= @certificate_thumbprint %>")) {
+                Get-Item Cert:\LocalMachine\$store\$cert.Thumbprint | Remove-Item <%= @ip_address %>!<%= @port %>!<%= @host_header %>
+            }
+        }
+    }
+    else {
+        exit 0
+    }
 }

--- a/templates/inspect-certificate-binding.ps1.erb
+++ b/templates/inspect-certificate-binding.ps1.erb
@@ -1,9 +1,10 @@
 Import-Module WebAdministration
 
-if((Test-Path IIS:\SslBindings\<%= @ip_address %>!<%= @port %>) -eq $true) {
+if((Test-Path IIS:\SslBindings\<%= @ip_address %>!<%= @port %>,IIS:\SslBindings\<%= @ip_address %>!<%= @port %>!<%= @host_header %>) -eq $true) {
     $site = Get-Website | Where-Object { $_.Name -eq "<%= @site_name %>" }
+    $store = "<%= @store %>"
     $certsAttachedToSite = Get-ChildItem IIS:\SSLBindings | ? { $site | Select-Object { $_ -contains $_.Sites.Value }} | % { $_.Thumbprint }
-    $certificate = Get-ChildItem CERT:\LocalMachine\My | ? { $certsAttachedToSite -contains $_.Thumbprint} | Where-Object { $_.Thumbprint -eq "<%= @certificate_thumbprint %>" }
+    $certificate = Get-ChildItem CERT:\LocalMachine\$store | ? { $certsAttachedToSite -contains $_.Thumbprint} | Where-Object { $_.Thumbprint -eq "<%= @certificate_thumbprint %>" }
     if ($certificate -ne $null ){
         exit 1
     }


### PR DESCRIPTION
Added two attributes to manage_binding defined type:
store
sslFlag

New-WebBinding now uses SslFlags parameter.

Templates updated to search for ssl bindings with host headers.

Example Usage:

  iis::manage_binding { "${site_name}-443":
    site_name              => $site_name,
    protocol               => 'https',
    port                   => '443',
    host_header            => $site_name,
    certificate_thumbprint => $cert_thumbprint,
    store                  => 'WebHosting',
    sslFlag                => '1',
    require                => Sslcertificate[ "${site_name}" ],
  }