### PR TITLE
Update iis_version.rb

### DIFF
--- a/lib/facter/iis_version.rb
+++ b/lib/facter/iis_version.rb
@@ -11,7 +11,7 @@ Facter.add("iis_version") do
                 'powershell.exe'
                end
 
-      iis_ver = %x{#{psexec} -ExecutionPolicy ByPass -Command "(Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\InetStp\\ -Name VersionString).VersionString.SubString(8,3)"}
+      iis_ver = %x{#{psexec} -ExecutionPolicy ByPass -Command "(Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\InetStp -ErrorAction SilentlyContinue -Name VersionString).Versionstring -replace 'Version ',''"}
     rescue
       iis_ver = ""
     end


### PR DESCRIPTION
Changed powershell code to retrieve IIS version a bit to enable support of higher version numbers (e.g. 10.0) and also to suppress error messages on systems that have no IIS installed.

Here is a snipped of the ugly error you get when using the module on systems that have no IIS installed yet.

tarenz-mac:puppet-winupdates tarenz$ vagrant provision
==> default: Running provisioner: puppet...
==> default: Running Puppet with default.pp...
==> default: Debug: Runtime environment: puppet_version=3.8.1, ruby_version=2.0.0, run_mode=user, default_encoding=IBM437
==> default: Debug: Loading external facts from C:/ProgramData/PuppetLabs/puppet/var/facts.d
==> default: 
==> default: Info: Loading facts
==> default: Debug: Loading facts from C:/tmp/vagrant-puppet/modules-32091fd4b132d1d57922ea3df525395f/iis/lib/facter/iis_version.rb
==> default: Info: Loading facts
==> default: Debug: Loading facts from C:/tmp/vagrant-puppet/modules-32091fd4b132d1d57922ea3df525395f/stdlib/lib/facter/facter_dot_d.rb
==> default: Debug: Loading facts from C:/tmp/vagrant-puppet/modules-32091fd4b132d1d57922ea3df525395f/stdlib/lib/facter/pe_version.rb
==> default: Debug: Loading facts from C:/tmp/vagrant-puppet/modules-32091fd4b132d1d57922ea3df525395f/stdlib/lib/facter/puppet_vardir.rb
==> default: Debug: Loading facts from C:/tmp/vagrant-puppet/modules-32091fd4b132d1d57922ea3df525395f/stdlib/lib/facter/root_home.rb
==> default: Get-ItemProperty : Cannot find path 'HKLM:\SOFTWARE\Microsoft\InetStp\' 
==> default: 
==> default: because it does not exist.
==> default: At line:1 char:2
==> default: + (Get-ItemProperty HKLM:\SOFTWARE\Microsoft\InetStp\ -Name 
==> default: VersionString).Version ...
==> default: +  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==> default:     + CategoryInfo          : ObjectNotFound: (HKLM:\SOFTWARE\Microsoft\InetSt 
==> default:    p\:String) [Get-ItemProperty], ItemNotFoundException
==> default:     + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetIt 
==> default:    emPropertyCommand
==> default:  
==> default: You cannot call a method on a null-valued expression.
==> default: At line:1 char:1
==> default: + (Get-ItemProperty HKLM:\SOFTWARE\Microsoft\InetStp\ -Name 
==> default: VersionString).Version ...
==> default: + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==> default: ~~~
==> default:     + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
==> default:     + FullyQualifiedErrorId : InvokeMethodOnNull
==> default:  
==> default: Notice: Compiled catalog for puppet-winupdates.localdomain in environment production in 0.27 seconds
