### PR TITLE
manage_app_pool - added app pool identity capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,39 @@ Host header and ip address can also be supplied.
       ip_address  => '192.168.0.1',
       host_header => 'mysite.com',
     }
+Notes on Managing App Pools
+--
+
+      class mywebsite {
+        iis::manage_app_pool {'my_application_pool0':
+			enable_32_bit				=> true,
+			managed_runtime_version	=> 'v4.0',
+			apppool_identitytype		=> 'ApplicationPoolIdentity', # ApplicationPoolIdentity (or '4') is the default an IIS app pool will be created with
+        }
+
+        iis::manage_app_pool {'my_application_pool1':
+			enable_32_bit				=> true,
+			managed_runtime_version	=> 'v4.0',
+			apppool_identitytype		=> 'LocalSystem', # LocalSystem (or '0')
+        }
+
+        iis::manage_app_pool {'my_application_pool2':
+			enable_32_bit				=> true,
+			managed_runtime_version	=> 'v4.0',
+			apppool_identitytype		=> 'LocalService', # LocalService (or '1')
+        }
+
+        iis::manage_app_pool {'my_application_pool3':
+			enable_32_bit           => true,
+			managed_runtime_version => 'v4.0',
+			apppool_identitytype	   => 'NetworkService', # NetworkService (or '2')
+        }
+
+        iis::manage_app_pool {'my_application_pool4':
+			enable_32_bit					=> true,
+			managed_runtime_version			=> 'v4.0',
+			apppool_identitytype			=> 'SpecificUser',	# SpecificUser (or '3'),
+			apppool_username				=> 'username',		# MUST specify a username when 'SpecificUser'/'3' for apppool_identitytype
+			apppool_userpw					=> 'password'			# MUST specify a password when 'SpecificUser'/'3' for apppool_identitytype
+		}
+       }

--- a/manifests/manage_app_pool.pp
+++ b/manifests/manage_app_pool.pp
@@ -1,14 +1,14 @@
-#
-define iis::manage_app_pool(
+define iis::manage_app_pool (
   $app_pool_name           = $title,
   $enable_32_bit           = false,
   $managed_runtime_version = 'v4.0',
   $managed_pipeline_mode   = 'Integrated',
   $ensure                  = 'present',
   $start_mode              = 'OnDemand',
-  $rapid_fail_protection   = true
-){
-
+  $rapid_fail_protection   = true,
+  $apppool_identitytype    = undef,
+  $apppool_username        = undef,
+  $apppool_userpw          = undef) {
   validate_bool($enable_32_bit)
   validate_re($managed_runtime_version, ['^(v2\.0|v4\.0|v4\.5)$'])
   validate_re($managed_pipeline_mode, ['^(Integrated|Classic)$'])
@@ -16,15 +16,63 @@ define iis::manage_app_pool(
   validate_re($start_mode, '^(OnDemand|AlwaysRunning)$')
   validate_bool($rapid_fail_protection)
 
+  # keeping new stuff optional for backwards compatibility
+  if $apppool_identitytype != undef {
+
+    validate_re($apppool_identitytype, ['^(0|1|2|3|4|LocalSystem|LocalService|NetworkService|SpecificUser|ApplicationPoolIdentity)$'], 'identitytype must be one of \'0\', \'1\',\'2\',\'3\',\'4\',\'LocalSystem\',\'LocalService\',\'NetworkService\',\'SpecificUser\',\'ApplicationPoolIdentity\'')
+
+    if ($apppool_identitytype in ['3','SpecificUser']) {
+      if ($apppool_username == undef) or (empty($apppool_username)) {
+        fail('attempt set app pool identity to SpecificUser null or zero length $apppool_username param')
+      }
+
+      if ($apppool_userpw == undef) or (empty($apppool_userpw)) {
+        fail('attempt set app pool identity to SpecificUser null or zero length $apppool_userpw param')
+      }
+    }
+
+    case $apppool_identitytype {
+      '0', 'LocalSystem'             : {
+        $identitystring = 'LocalSystem'
+        $identityenum   = '0'
+      }
+      '1', 'LocalService'            : {
+        $identitystring = 'LocalService'
+        $identityenum   = '1'
+      }
+      '2', 'NetworkService'          : {
+        $identitystring = 'NetworkService'
+        $identityenum   = '2'
+      }
+      '3', 'SpecificUser'            : {
+        $identitystring = 'SpecificUser'
+        $identityenum   = '3'
+      }
+      '4', 'ApplicationPoolIdentity' : {
+        $identitystring = 'ApplicationPoolIdentity'
+        $identityenum   = '4'
+      }
+      default : {
+        $identitystring = 'ApplicationPoolIdentity'
+        $identityenum   = '4'
+      }
+    }
+
+    $process_apppool_identity = true
+
+  }
+  else
+  {$process_apppool_identity = false}
+
   if ($ensure in ['present','installed']) {
-    exec { "Create-${app_pool_name}" :
+    exec { "Create-${app_pool_name}":
       command   => "Import-Module WebAdministration; New-Item \"IIS:\\AppPools\\${app_pool_name}\"",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Test-Path \"IIS:\\AppPools\\${app_pool_name}\")) { exit 1 } else { exit 0 }",
       logoutput => true,
     }
 
-    exec { "StartMode-${app_pool_name}" :
+    exec { "StartMode-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode ${start_mode}",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode).CompareTo('${start_mode}') -eq 0) { exit 1 } else { exit 0 }",
@@ -32,7 +80,7 @@ define iis::manage_app_pool(
       logoutput => true,
     }
 
-    exec { "RapidFailProtection-${app_pool_name}" :
+    exec { "RapidFailProtection-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" failure.rapidFailProtection ${rapid_fail_protection}",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" failure.rapidFailProtection).Value -eq [System.Convert]::ToBoolean('${rapid_fail_protection}')) { exit 1 } else { exit 0 }",
@@ -40,7 +88,7 @@ define iis::manage_app_pool(
       logoutput => true,
     }
 
-    exec { "Framework-${app_pool_name}" :
+    exec { "Framework-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" managedRuntimeVersion ${managed_runtime_version}",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" managedRuntimeVersion).Value.CompareTo('${managed_runtime_version}') -eq 0) { exit 1 } else { exit 0 }",
@@ -48,7 +96,7 @@ define iis::manage_app_pool(
       logoutput => true,
     }
 
-    exec { "32bit-${app_pool_name}" :
+    exec { "32bit-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" enable32BitAppOnWin64 ${enable_32_bit}",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" enable32BitAppOnWin64).Value -eq [System.Convert]::ToBoolean('${enable_32_bit}')) { exit 1 } else { exit 0 }",
@@ -62,19 +110,42 @@ define iis::manage_app_pool(
       default      => 0,
     }
 
-    exec { "ManagedPipelineMode-${app_pool_name}" :
+    exec { "ManagedPipelineMode-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" managedPipelineMode ${managed_pipeline_mode_value}",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" managedPipelineMode).CompareTo('${managed_pipeline_mode}') -eq 0) { exit 1 } else { exit 0 }",
       require   => Exec["Create-${app_pool_name}"],
       logoutput => true,
     }
+
+    if ($process_apppool_identity) {
+      if ($identitystring == 'SpecificUser') {
+        exec { "app pool identitytype - ${app_pool_name} - SPECIFICUSER - ${apppool_username}":
+          command   => "Import-Module WebAdministration;\$iis = New-Object Microsoft.Web.Administration.ServerManager;iis:;\$pool = get-item IIS:\\AppPools\\${app_pool_name};\$pool.processModel.username = \"${apppool_username}\";\$pool.processModel.password = \"${apppool_userpw}\";\$pool.processModel.identityType = ${identityenum};\$pool | set-item;",
+          provider  => powershell,
+          unless    => "Import-Module WebAdministration;\$iis = New-Object Microsoft.Web.Administration.ServerManager;iis:;\$pool = get-item IIS:\\AppPools\\${app_pool_name};if(\$pool.processModel.identityType -ne \"${identitystring}\"){exit 1;}\
+if(\$pool.processModel.userName -ne ${apppool_username}){exit 1;}if(\$pool.processModel.password -ne ${apppool_userpw}){exit 1;}exit 0;",
+          require   => Exec["Create-${app_pool_name}"],
+          logoutput => true,
+        }
+      } else {
+        exec { "app pool identitytype - ${app_pool_name} - ${identitystring}":
+          command   => "Import-Module WebAdministration;\$iis = New-Object Microsoft.Web.Administration.ServerManager;iis:;\$pool = get-item IIS:\\AppPools\\${app_pool_name};\$pool.processModel.identityType = ${identityenum};\$pool | set-item;",
+          provider  => powershell,
+          unless    => "Import-Module WebAdministration;\$iis = New-Object Microsoft.Web.Administration.ServerManager;iis:;\$pool = get-item IIS:\\AppPools\\${app_pool_name};if(\$pool.processModel.identityType -eq \"${identitystring}\"){exit 0;}else{exit 1;}",
+          require   => Exec["Create-${app_pool_name}"],
+          logoutput => true,
+        }
+      }
+    }
+
   } else {
-    exec { "Delete-${app_pool_name}" :
+    exec { "Delete-${app_pool_name}":
       command   => "Import-Module WebAdministration; Remove-Item \"IIS:\\AppPools\\${app_pool_name}\" -Recurse",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if(!(Test-Path \"IIS:\\AppPools\\${app_pool_name}\")) { exit 1 } else { exit 0 }",
       logoutput => true,
     }
+
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/powershell",

--- a/spec/defines/manage_app_pool_spec.rb
+++ b/spec/defines/manage_app_pool_spec.rb
@@ -6,7 +6,8 @@ describe 'iis::manage_app_pool', :type => :define do
     let(:params) {{
       :enable_32_bit           => true,
       :managed_runtime_version => 'v4.0',
-      :managed_pipeline_mode   => 'Integrated'
+      :managed_pipeline_mode   => 'Integrated',
+      :apppool_identitytype    => 'ApplicationPoolIdentity'
     }}
 
     it { should contain_exec('Create-myAppPool.example.com').with(
@@ -30,6 +31,55 @@ describe 'iis::manage_app_pool', :type => :define do
       :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 0",
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Integrated') -eq 0) { exit 1 } else { exit 0 }",)
     }
+
+    it { should contain_exec('app pool identitytype - myAppPool.example.com - ApplicationPoolIdentity').with(
+      :command => "Import-Module WebAdministration;\$iis = New-Object Microsoft.Web.Administration.ServerManager;iis:;\$pool = get-item IIS:\\AppPools\\myAppPool.example.com;\$pool.processModel.identityType = 4;\$pool | set-item;",
+      :unless  => "Import-Module WebAdministration;\$iis = New-Object Microsoft.Web.Administration.ServerManager;iis:;\$pool = get-item IIS:\\AppPools\\myAppPool.example.com;if(\$pool.processModel.identityType -eq \"ApplicationPoolIdentity\"){exit 0;}else{exit 1;}",)
+    }
+
+    it { should_not contain_exec('app pool identitytype - myAppPool.example.com - SPECIFICUSER - username') }
+  end
+
+  describe 'when managing the iis application pool with SpecificUser identitytype' do
+    let(:title) { 'myAppPool.example.com' }
+    let(:params) {{
+      :enable_32_bit           => true,
+      :managed_runtime_version => 'v4.0',
+      :managed_pipeline_mode   => 'Integrated',
+      :apppool_identitytype    => 'SpecificUser',
+      :apppool_username		   => 'username',
+      :apppool_userpw		   => 'password'
+    }}
+
+    it { should contain_exec('Create-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; New-Item \"IIS:\\AppPools\\myAppPool.example.com\"",
+      :onlyif  => "Import-Module WebAdministration; if((Test-Path \"IIS:\\AppPools\\myAppPool.example.com\")) { exit 1 } else { exit 0 }",)
+    }
+
+    it { should contain_exec('Framework-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedRuntimeVersion v4.0",
+      :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedRuntimeVersion).Value.CompareTo(\'v4.0\') -eq 0) { exit 1 } else { exit 0 }",
+      :require => 'Exec[Create-myAppPool.example.com]',)
+    }
+
+    it { should contain_exec('32bit-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" enable32BitAppOnWin64 true",
+      :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" enable32BitAppOnWin64).Value -eq [System.Convert]::ToBoolean(\'true\')) { exit 1 } else { exit 0 }",
+      :require => 'Exec[Create-myAppPool.example.com]',)
+    }
+
+    it { should contain_exec('ManagedPipelineMode-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 0",
+      :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Integrated') -eq 0) { exit 1 } else { exit 0 }",)
+    }
+
+    it { should contain_exec('app pool identitytype - myAppPool.example.com - SPECIFICUSER - username').with(
+      :command => "Import-Module WebAdministration;\$iis = New-Object Microsoft.Web.Administration.ServerManager;iis:;\$pool = get-item IIS:\\AppPools\\myAppPool.example.com;\$pool.processModel.username = \"username\";\$pool.processModel.password = \"password\";\$pool.processModel.identityType = 3;\$pool | set-item;",
+      :unless  => "Import-Module WebAdministration;\$iis = New-Object Microsoft.Web.Administration.ServerManager;iis:;\$pool = get-item IIS:\\AppPools\\myAppPool.example.com;if(\$pool.processModel.identityType -ne \"SpecificUser\"){exit 1;}\
+if(\$pool.processModel.userName -ne username){exit 1;}if(\$pool.processModel.password -ne password){exit 1;}exit 0;",)
+    }
+
+    it { should_not contain_exec('app pool identitytype - myAppPool.example.com - ApplicationPoolIdentity') }
   end
 
   describe 'when managing the iis application pool - v2.0 Classic' do
@@ -61,6 +111,51 @@ describe 'iis::manage_app_pool', :type => :define do
       :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 1",
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Classic') -eq 0) { exit 1 } else { exit 0 }",)
     }
+
+    it { should_not contain_exec('app pool identitytype - myAppPool.example.com - ApplicationPoolIdentity') }
+    it { should_not contain_exec('app pool identitytype - myAppPool.example.com - SPECIFICUSER - username') }
+  end
+
+  describe 'when managing the iis application pool - v2.0 Classic with SpecificUser identitytype' do
+    let(:title) { 'myAppPool.example.com' }
+    let(:params) {{
+      :enable_32_bit           => true,
+      :managed_runtime_version => 'v2.0',
+      :managed_pipeline_mode   => 'Classic',
+      :apppool_identitytype    => 'SpecificUser',
+      :apppool_username		   => 'username',
+      :apppool_userpw		   => 'password'
+    }}
+
+    it { should contain_exec('Create-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; New-Item \"IIS:\\AppPools\\myAppPool.example.com\"",
+      :onlyif  => "Import-Module WebAdministration; if((Test-Path \"IIS:\\AppPools\\myAppPool.example.com\")) { exit 1 } else { exit 0 }",)
+    }
+
+    it { should contain_exec('Framework-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedRuntimeVersion v2.0",
+      :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedRuntimeVersion).Value.CompareTo(\'v2.0\') -eq 0) { exit 1 } else { exit 0 }",
+      :require => 'Exec[Create-myAppPool.example.com]',)
+    }
+
+    it { should contain_exec('32bit-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" enable32BitAppOnWin64 true",
+      :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" enable32BitAppOnWin64).Value -eq [System.Convert]::ToBoolean(\'true\')) { exit 1 } else { exit 0 }",
+      :require => 'Exec[Create-myAppPool.example.com]',)
+    }
+
+    it { should contain_exec('ManagedPipelineMode-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 1",
+      :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Classic') -eq 0) { exit 1 } else { exit 0 }",)
+    }
+
+    it { should contain_exec('app pool identitytype - myAppPool.example.com - SPECIFICUSER - username').with(
+      :command => "Import-Module WebAdministration;\$iis = New-Object Microsoft.Web.Administration.ServerManager;iis:;\$pool = get-item IIS:\\AppPools\\myAppPool.example.com;\$pool.processModel.username = \"username\";\$pool.processModel.password = \"password\";\$pool.processModel.identityType = 3;\$pool | set-item;",
+      :unless  => "Import-Module WebAdministration;\$iis = New-Object Microsoft.Web.Administration.ServerManager;iis:;\$pool = get-item IIS:\\AppPools\\myAppPool.example.com;if(\$pool.processModel.identityType -ne \"SpecificUser\"){exit 1;}\
+if(\$pool.processModel.userName -ne username){exit 1;}if(\$pool.processModel.password -ne password){exit 1;}exit 0;",)
+    }
+
+    it { should_not contain_exec('app pool identitytype - myAppPool.example.com - ApplicationPoolIdentity') }
   end
 
   describe 'when managing the iis application pool without passing parameters' do
@@ -87,6 +182,9 @@ describe 'iis::manage_app_pool', :type => :define do
       :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 0",
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Integrated') -eq 0) { exit 1 } else { exit 0 }",)
     }
+
+    it { should_not contain_exec('app pool identitytype - myAppPool.example.com - ApplicationPoolIdentity') }
+    it { should_not contain_exec('app pool identitytype - myAppPool.example.com - SPECIFICUSER - username') }
   end
 
   describe 'when managing the iis application with a managed_runtime_version of v2.0' do
@@ -136,6 +234,34 @@ describe 'iis::manage_app_pool', :type => :define do
     it { expect { should contain_exec('Create-myAppPool.example.com') }.to raise_error(Puppet::Error, /"false" is not a boolean\./) }
   end
 
+  describe 'when managing the iis application and identity type invalid' do
+    let(:title) { 'myAppPool.example.com' }
+    let(:params) { { :apppool_identitytype => '5' } }
+
+    it { expect { should contain_exec('Create-myAppPool.example.com') }.to raise_error(Puppet::Error, /identitytype must be one of \'0\', \'1\',\'2\',\'3\',\'4\',\'LocalSystem\',\'LocalService\',\'NetworkService\',\'SpecificUser\',\'ApplicationPoolIdentity\'/) }
+  end
+
+  describe 'when managing the iis application and identity SpecificUser and no username supplied' do
+    let(:title) { 'myAppPool.example.com' }
+    let(:params) { { :apppool_identitytype => '3', :apppool_userpw => 'password' } }
+
+    it { expect { should contain_exec('Create-myAppPool.example.com') }.to raise_error(Puppet::Error, /attempt set app pool identity to SpecificUser null or zero length \$apppool_username param/) }
+  end
+
+  describe 'when managing the iis application and identity SpecificUser and no password supplied' do
+    let(:title) { 'myAppPool.example.com' }
+    let(:params) { { :apppool_identitytype => '3', :apppool_username => 'username' } }
+
+    it { expect { should contain_exec('Create-myAppPool.example.com') }.to raise_error(Puppet::Error, /attempt set app pool identity to SpecificUser null or zero length \$apppool_userpw param/) }
+  end
+
+  describe 'when managing the iis application and identity SpecificUser and no username or password supplied' do
+    let(:title) { 'myAppPool.example.com' }
+    let(:params) { { :apppool_identitytype => '3' } }
+
+    it { expect { should contain_exec('Create-myAppPool.example.com') }.to raise_error(Puppet::Error, /attempt set app pool identity to SpecificUser null or zero length \$apppool_username param/) }
+  end
+
   describe 'when managing the iis application pool and setting ensure to present' do
     let(:title) { 'myAppPool.example.com' }
     let(:params) { { :ensure => 'present' } }
@@ -183,6 +309,10 @@ describe 'iis::manage_app_pool', :type => :define do
       :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 0",
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Integrated') -eq 0) { exit 1 } else { exit 0 }",)
     }
+
+    it { should_not contain_exec('app pool identitytype - myAppPool.example.com - ApplicationPoolIdentity') }
+
+    it { should_not contain_exec('app pool identitytype - myAppPool.example.com - SPECIFICUSER - username') }
   end
 
   describe 'when managing the iis application pool and setting ensure to absent' do
@@ -199,6 +329,10 @@ describe 'iis::manage_app_pool', :type => :define do
     it { should_not contain_exec('32bit-myAppPool.example.com') }
 
     it { should_not contain_exec('ManagedPipelineMode-myAppPool.example.com') }
+
+    it { should_not contain_exec('app pool identitytype - myAppPool.example.com - ApplicationPoolIdentity') }
+
+    it { should_not contain_exec('app pool identitytype - myAppPool.example.com - SPECIFICUSER - username') }
   end
 
   describe 'when managing the iis application pool and setting ensure to purged' do
@@ -215,5 +349,9 @@ describe 'iis::manage_app_pool', :type => :define do
     it { should_not contain_exec('32bit-myAppPool.example.com') }
 
     it { should_not contain_exec('ManagedPipelineMode-myAppPool.example.com') }
+
+    it { should_not contain_exec('app pool identitytype - myAppPool.example.com - ApplicationPoolIdentity') }
+
+    it { should_not contain_exec('app pool identitytype - myAppPool.example.com - SPECIFICUSER - username') }
   end
 end


### PR DESCRIPTION
new params kept optional as undef to allow for backwards compatibility,
logic in class will handle undef

Caller MUST specify $apppoolusername $apppoolpassword if using
"SpecificUser" identity type