### PR TITLE
 manage_app_pool - add max processes control

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,13 @@ Host header and ip address can also be supplied.
       ip_address  => '192.168.0.1',
       host_header => 'mysite.com',
     }
+
+Notes on Managing App Pools
+--
+
+      class mywebsite {
+        iis::manage_app_pool {'my_application_pool':
+			enable_32_bit           => true,
+			managed_runtime_version => 'v4.0',
+			apppool_max_processes   => 0, # 0 lets iis detect optimal on numa system, not enforcing max (its an int64)
+        }

--- a/manifests/manage_app_pool.pp
+++ b/manifests/manage_app_pool.pp
@@ -1,14 +1,12 @@
-#
-define iis::manage_app_pool(
+define iis::manage_app_pool (
   $app_pool_name           = $title,
   $enable_32_bit           = false,
   $managed_runtime_version = 'v4.0',
   $managed_pipeline_mode   = 'Integrated',
   $ensure                  = 'present',
   $start_mode              = 'OnDemand',
-  $rapid_fail_protection   = true
-){
-
+  $rapid_fail_protection   = true,
+  $apppool_max_processes   = undef) {
   validate_bool($enable_32_bit)
   validate_re($managed_runtime_version, ['^(v2\.0|v4\.0|v4\.5)$'])
   validate_re($managed_pipeline_mode, ['^(Integrated|Classic)$'])
@@ -16,15 +14,22 @@ define iis::manage_app_pool(
   validate_re($start_mode, '^(OnDemand|AlwaysRunning)$')
   validate_bool($rapid_fail_protection)
 
+  if $apppool_max_processes != undef {
+    validate_integer($apppool_max_processes, undef, 0)
+    $process_max_processes = true
+  } else {
+    $process_max_processes = false
+  }
+
   if ($ensure in ['present','installed']) {
-    exec { "Create-${app_pool_name}" :
+    exec { "Create-${app_pool_name}":
       command   => "Import-Module WebAdministration; New-Item \"IIS:\\AppPools\\${app_pool_name}\"",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Test-Path \"IIS:\\AppPools\\${app_pool_name}\")) { exit 1 } else { exit 0 }",
       logoutput => true,
     }
 
-    exec { "StartMode-${app_pool_name}" :
+    exec { "StartMode-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode ${start_mode}",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode).CompareTo('${start_mode}') -eq 0) { exit 1 } else { exit 0 }",
@@ -32,7 +37,7 @@ define iis::manage_app_pool(
       logoutput => true,
     }
 
-    exec { "RapidFailProtection-${app_pool_name}" :
+    exec { "RapidFailProtection-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" failure.rapidFailProtection ${rapid_fail_protection}",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" failure.rapidFailProtection).Value -eq [System.Convert]::ToBoolean('${rapid_fail_protection}')) { exit 1 } else { exit 0 }",
@@ -40,7 +45,7 @@ define iis::manage_app_pool(
       logoutput => true,
     }
 
-    exec { "Framework-${app_pool_name}" :
+    exec { "Framework-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" managedRuntimeVersion ${managed_runtime_version}",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" managedRuntimeVersion).Value.CompareTo('${managed_runtime_version}') -eq 0) { exit 1 } else { exit 0 }",
@@ -48,7 +53,7 @@ define iis::manage_app_pool(
       logoutput => true,
     }
 
-    exec { "32bit-${app_pool_name}" :
+    exec { "32bit-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" enable32BitAppOnWin64 ${enable_32_bit}",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" enable32BitAppOnWin64).Value -eq [System.Convert]::ToBoolean('${enable_32_bit}')) { exit 1 } else { exit 0 }",
@@ -62,15 +67,26 @@ define iis::manage_app_pool(
       default      => 0,
     }
 
-    exec { "ManagedPipelineMode-${app_pool_name}" :
+    exec { "ManagedPipelineMode-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" managedPipelineMode ${managed_pipeline_mode_value}",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" managedPipelineMode).CompareTo('${managed_pipeline_mode}') -eq 0) { exit 1 } else { exit 0 }",
       require   => Exec["Create-${app_pool_name}"],
       logoutput => true,
     }
+
+    if ($process_max_processes) {
+      exec { "App Pool Max Processes - ${app_pool_name}":
+        command   => "Import-Module WebAdministration;\$appPoolPath = (\"IIS:\\AppPools\\\" + \"${app_pool_name}\");Set-ItemProperty \$appPoolPath -name processModel -value @{maxProcesses=${apppool_max_processes}}",
+        provider  => powershell,
+        unless    => "Import-Module WebAdministration;\$appPoolPath = (\"IIS:\\AppPools\\\" + \"${app_pool_name}\");if((get-ItemProperty \$appPoolPath -name processModel.maxprocesses.value) -ne ${apppool_max_processes}){exit 1;}exit 0;",
+        require   => Exec["Create-${app_pool_name}"],
+        logoutput => true,
+      }
+    }
+
   } else {
-    exec { "Delete-${app_pool_name}" :
+    exec { "Delete-${app_pool_name}":
       command   => "Import-Module WebAdministration; Remove-Item \"IIS:\\AppPools\\${app_pool_name}\" -Recurse",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if(!(Test-Path \"IIS:\\AppPools\\${app_pool_name}\")) { exit 1 } else { exit 0 }",

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/powershell",

--- a/spec/defines/manage_app_pool_spec.rb
+++ b/spec/defines/manage_app_pool_spec.rb
@@ -6,7 +6,8 @@ describe 'iis::manage_app_pool', :type => :define do
     let(:params) {{
       :enable_32_bit           => true,
       :managed_runtime_version => 'v4.0',
-      :managed_pipeline_mode   => 'Integrated'
+      :managed_pipeline_mode   => 'Integrated',
+      :apppool_max_processes   => 0
     }}
 
     it { should contain_exec('Create-myAppPool.example.com').with(
@@ -30,6 +31,11 @@ describe 'iis::manage_app_pool', :type => :define do
       :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 0",
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Integrated') -eq 0) { exit 1 } else { exit 0 }",)
     }
+
+    it { should contain_exec('App Pool Max Processes - myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration;\$appPoolPath = (\"IIS:\\AppPools\\\" + \"myAppPool.example.com\");Set-ItemProperty \$appPoolPath -name processModel -value @{maxProcesses=0}",
+      :unless  => "Import-Module WebAdministration;\$appPoolPath = (\"IIS:\\AppPools\\\" + \"myAppPool.example.com\");if((get-ItemProperty \$appPoolPath -name processModel.maxprocesses.value) -ne 0){exit 1;}exit 0;",)
+    }
   end
 
   describe 'when managing the iis application pool - v2.0 Classic' do
@@ -37,7 +43,8 @@ describe 'iis::manage_app_pool', :type => :define do
     let(:params) {{
       :enable_32_bit           => true,
       :managed_runtime_version => 'v2.0',
-      :managed_pipeline_mode   => 'Classic'
+      :managed_pipeline_mode   => 'Classic',
+      :apppool_max_processes   => 0
     }}
 
     it { should contain_exec('Create-myAppPool.example.com').with(
@@ -60,6 +67,11 @@ describe 'iis::manage_app_pool', :type => :define do
     it { should contain_exec('ManagedPipelineMode-myAppPool.example.com').with(
       :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 1",
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Classic') -eq 0) { exit 1 } else { exit 0 }",)
+    }
+
+    it { should contain_exec('App Pool Max Processes - myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration;\$appPoolPath = (\"IIS:\\AppPools\\\" + \"myAppPool.example.com\");Set-ItemProperty \$appPoolPath -name processModel -value @{maxProcesses=0}",
+      :unless  => "Import-Module WebAdministration;\$appPoolPath = (\"IIS:\\AppPools\\\" + \"myAppPool.example.com\");if((get-ItemProperty \$appPoolPath -name processModel.maxprocesses.value) -ne 0){exit 1;}exit 0;",)
     }
   end
 
@@ -87,6 +99,8 @@ describe 'iis::manage_app_pool', :type => :define do
       :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 0",
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Integrated') -eq 0) { exit 1 } else { exit 0 }",)
     }
+
+    it { should_not contain_exec('App Pool Max Processes - myAppPool.example.com') }
   end
 
   describe 'when managing the iis application with a managed_runtime_version of v2.0' do
@@ -199,6 +213,8 @@ describe 'iis::manage_app_pool', :type => :define do
     it { should_not contain_exec('32bit-myAppPool.example.com') }
 
     it { should_not contain_exec('ManagedPipelineMode-myAppPool.example.com') }
+
+    it { should_not contain_exec('App Pool Max Processes - myAppPool.example.com') }
   end
 
   describe 'when managing the iis application pool and setting ensure to purged' do
@@ -215,5 +231,7 @@ describe 'iis::manage_app_pool', :type => :define do
     it { should_not contain_exec('32bit-myAppPool.example.com') }
 
     it { should_not contain_exec('ManagedPipelineMode-myAppPool.example.com') }
+
+    it { should_not contain_exec('App Pool Max Processes - myAppPool.example.com') }
   end
 end


### PR DESCRIPTION
manage_app_pool - add max processes control

new params kept undef defaults for backward compatibility

setting 0 here will let IIS detect optimal max processes count on NUMA
aware system.

not enforcing a max on maximum processes you can throw at an app pool,
admin knows system.  it's a (signed) int64