### PR TITLE
manage_app_pool - add scheduled recycling control

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,20 @@ Host header and ip address can also be supplied.
       ip_address  => '192.168.0.1',
       host_header => 'mysite.com',
     }
+
+Notes on Managing App Pools
+--
+
+      class mywebsite {
+        iis::manage_app_pool {'my_application_pool':
+			enable_32_bit           => true,
+			managed_runtime_version => 'v4.0',
+			apppool_recycle_schedule   => ['01:00:00','23:59:59'] # apppool scheduled recycling ['hh:mm:ss','...'] - empty array to clear scheduled recycling on an app pool
+        }
+
+        iis::manage_app_pool {'my_application_pool0':
+			enable_32_bit           => true,
+			managed_runtime_version => 'v4.0',
+			apppool_recycle_schedule   => [] # empty array to clear scheduled recycling on an app pool
+        }
+      }

--- a/manifests/manage_app_pool.pp
+++ b/manifests/manage_app_pool.pp
@@ -1,14 +1,12 @@
-#
-define iis::manage_app_pool(
+define iis::manage_app_pool (
   $app_pool_name           = $title,
   $enable_32_bit           = false,
   $managed_runtime_version = 'v4.0',
   $managed_pipeline_mode   = 'Integrated',
   $ensure                  = 'present',
   $start_mode              = 'OnDemand',
-  $rapid_fail_protection   = true
-){
-
+  $rapid_fail_protection   = true,
+  $apppool_recycle_schedule  = undef) {
   validate_bool($enable_32_bit)
   validate_re($managed_runtime_version, ['^(v2\.0|v4\.0|v4\.5)$'])
   validate_re($managed_pipeline_mode, ['^(Integrated|Classic)$'])
@@ -16,8 +14,24 @@ define iis::manage_app_pool(
   validate_re($start_mode, '^(OnDemand|AlwaysRunning)$')
   validate_bool($rapid_fail_protection)
 
+  if $apppool_recycle_schedule != undef {
+    if (!empty($apppool_recycle_schedule)) {
+      $restart_times_string = join($apppool_recycle_schedule, ',')
+      validate_re($restart_times_string, '^\d{2}:\d{2}:\d{2}$|^\b\d{2}:\d{2}:\d{2}(?:,\b\d{2}:\d{2}:\d{2}\b)*$',
+      "${restart_times_string} bad - time format hh:mm:ss in array")
+      $temptimestr           = regsubst($restart_times_string, '([,]+)', "\"\\1\"", 'G')
+      $fixed_times_string      = "\"${temptimestr}\""
+
+      $processscheduledtimes = true
+    } else {
+      $processscheduledtimes = true
+    }
+  } else {
+    $processscheduledtimes = false
+  }
+
   if ($ensure in ['present','installed']) {
-    exec { "Create-${app_pool_name}" :
+    exec { "Create-${app_pool_name}":
       command   => "Import-Module WebAdministration; New-Item \"IIS:\\AppPools\\${app_pool_name}\"",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Test-Path \"IIS:\\AppPools\\${app_pool_name}\")) { exit 1 } else { exit 0 }",
@@ -32,7 +46,7 @@ define iis::manage_app_pool(
       logoutput => true,
     }
 
-    exec { "RapidFailProtection-${app_pool_name}" :
+    exec { "RapidFailProtection-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" failure.rapidFailProtection ${rapid_fail_protection}",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" failure.rapidFailProtection).Value -eq [System.Convert]::ToBoolean('${rapid_fail_protection}')) { exit 1 } else { exit 0 }",
@@ -48,7 +62,7 @@ define iis::manage_app_pool(
       logoutput => true,
     }
 
-    exec { "32bit-${app_pool_name}" :
+    exec { "32bit-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" enable32BitAppOnWin64 ${enable_32_bit}",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" enable32BitAppOnWin64).Value -eq [System.Convert]::ToBoolean('${enable_32_bit}')) { exit 1 } else { exit 0 }",
@@ -62,15 +76,38 @@ define iis::manage_app_pool(
       default      => 0,
     }
 
-    exec { "ManagedPipelineMode-${app_pool_name}" :
+    exec { "ManagedPipelineMode-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" managedPipelineMode ${managed_pipeline_mode_value}",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" managedPipelineMode).CompareTo('${managed_pipeline_mode}') -eq 0) { exit 1 } else { exit 0 }",
       require   => Exec["Create-${app_pool_name}"],
       logoutput => true,
     }
+
+    if ($processscheduledtimes) {
+      if (empty($apppool_recycle_schedule)) {
+        exec { "CLEAR App Pool Recycle Schedule - ${app_pool_name}":
+          command   => "[string]\$ApplicationPoolName = \"${app_pool_name}\";Import-Module WebAdministration;Write-Output \"removing scheduled recycles\";Clear-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule;",
+          provider  => powershell,
+          unless    => "[string]\$ApplicationPoolName = \"${app_pool_name}\";Import-Module WebAdministration;if((Get-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule.collection).Length -eq \$null){exit 0;}else{exit 1;}",
+          require   => Exec["Create-${app_pool_name}"],
+          logoutput => true,
+        }
+      } else {
+        exec { "App Pool Recycle Schedule - ${app_pool_name} - ${fixed_times_string}":
+          command   => "[string]\$ApplicationPoolName = \"${app_pool_name}\";[string[]]\$RestartTimes = @(${fixed_times_string});Import-Module WebAdministration;Clear-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule;\
+foreach (\$restartTime in \$RestartTimes){Write-Output \"Adding recycle at \$restartTime\";New-ItemProperty -Path \"IIS:\\AppPools\\\$ApplicationPoolName\" -Name Recycling.periodicRestart.schedule -Value @{value=\$restartTime};}",
+          provider  => powershell,
+          unless    => "[string]\$ApplicationPoolName = \"${app_pool_name}\";[string[]]\$RestartTimes = @(${fixed_times_string});Import-Module WebAdministration;[Collections.Generic.List[String]]\$collectionAsList = @();\
+for(\$i=0; \$i -lt (Get-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule.collection).Count; \$i++){\$collectionAsList.Add((Get-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule.collection)[\$i].value.ToString());}\
+if(\$collectionAsList.Count -ne \$RestartTimes.Length){exit 1;}foreach (\$restartTime in \$RestartTimes) {if(!\$collectionAsList.Contains(\$restartTime)){exit 1;}}exit 0;",
+          require   => Exec["Create-${app_pool_name}"],
+          logoutput => true,
+        }
+      }
+    }
   } else {
-    exec { "Delete-${app_pool_name}" :
+    exec { "Delete-${app_pool_name}":
       command   => "Import-Module WebAdministration; Remove-Item \"IIS:\\AppPools\\${app_pool_name}\" -Recurse",
       provider  => powershell,
       onlyif    => "Import-Module WebAdministration; if(!(Test-Path \"IIS:\\AppPools\\${app_pool_name}\")) { exit 1 } else { exit 0 }",

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/powershell",

--- a/spec/defines/manage_app_pool_spec.rb
+++ b/spec/defines/manage_app_pool_spec.rb
@@ -6,7 +6,8 @@ describe 'iis::manage_app_pool', :type => :define do
     let(:params) {{
       :enable_32_bit           => true,
       :managed_runtime_version => 'v4.0',
-      :managed_pipeline_mode   => 'Integrated'
+      :managed_pipeline_mode   => 'Integrated',
+      :apppool_recycle_schedule => %w(01:00:00 23:59:59)
     }}
 
     it { should contain_exec('Create-myAppPool.example.com').with(
@@ -30,6 +31,55 @@ describe 'iis::manage_app_pool', :type => :define do
       :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 0",
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Integrated') -eq 0) { exit 1 } else { exit 0 }",)
     }
+
+    it { should contain_exec("App Pool Recycle Schedule - myAppPool.example.com - \"01:00:00\",\"23:59:59\"").with(
+      :command => "[string]\$ApplicationPoolName = \"myAppPool.example.com\";[string[]]\$RestartTimes = @(\"01:00:00\",\"23:59:59\");Import-Module WebAdministration;Clear-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule;\
+foreach (\$restartTime in \$RestartTimes){Write-Output \"Adding recycle at \$restartTime\";New-ItemProperty -Path \"IIS:\\AppPools\\\$ApplicationPoolName\" -Name Recycling.periodicRestart.schedule -Value @{value=\$restartTime};}",
+      :unless  => "[string]\$ApplicationPoolName = \"myAppPool.example.com\";[string[]]\$RestartTimes = @(\"01:00:00\",\"23:59:59\");Import-Module WebAdministration;[Collections.Generic.List[String]]\$collectionAsList = @();\
+for(\$i=0; \$i -lt (Get-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule.collection).Count; \$i++){\$collectionAsList.Add((Get-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule.collection)[\$i].value.ToString());}\
+if(\$collectionAsList.Count -ne \$RestartTimes.Length){exit 1;}foreach (\$restartTime in \$RestartTimes) {if(!\$collectionAsList.Contains(\$restartTime)){exit 1;}}exit 0;",)
+    }
+
+    it { should_not contain_exec(/CLEAR App Pool Recycle Schedule.*/) }
+  end
+
+  describe 'when managing the iis application pool and clearing scheduled app pool recycling' do
+    let(:title) { 'myAppPool.example.com' }
+    let(:params) {{
+      :enable_32_bit           => true,
+      :managed_runtime_version => 'v4.0',
+      :managed_pipeline_mode   => 'Integrated',
+      :apppool_recycle_schedule => []
+    }}
+
+    it { should contain_exec('Create-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; New-Item \"IIS:\\AppPools\\myAppPool.example.com\"",
+      :onlyif  => "Import-Module WebAdministration; if((Test-Path \"IIS:\\AppPools\\myAppPool.example.com\")) { exit 1 } else { exit 0 }",)
+    }
+
+    it { should contain_exec('Framework-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedRuntimeVersion v4.0",
+      :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedRuntimeVersion).Value.CompareTo(\'v4.0\') -eq 0) { exit 1 } else { exit 0 }",
+      :require => 'Exec[Create-myAppPool.example.com]',)
+    }
+
+    it { should contain_exec('32bit-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" enable32BitAppOnWin64 true",
+      :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" enable32BitAppOnWin64).Value -eq [System.Convert]::ToBoolean(\'true\')) { exit 1 } else { exit 0 }",
+      :require => 'Exec[Create-myAppPool.example.com]',)
+    }
+
+    it { should contain_exec('ManagedPipelineMode-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 0",
+      :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Integrated') -eq 0) { exit 1 } else { exit 0 }",)
+    }
+
+    it { should contain_exec('CLEAR App Pool Recycle Schedule - myAppPool.example.com').with(
+      :command => "[string]\$ApplicationPoolName = \"myAppPool.example.com\";Import-Module WebAdministration;Write-Output \"removing scheduled recycles\";Clear-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule;",
+      :unless  => "[string]\$ApplicationPoolName = \"myAppPool.example.com\";Import-Module WebAdministration;if((Get-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule.collection).Length -eq \$null){exit 0;}else{exit 1;}",)
+    }
+
+    it { should_not contain_exec(/App Pool Recycle Schedule.*/) }
   end
 
   describe 'when managing the iis application pool - v2.0 Classic' do
@@ -37,7 +87,8 @@ describe 'iis::manage_app_pool', :type => :define do
     let(:params) {{
       :enable_32_bit           => true,
       :managed_runtime_version => 'v2.0',
-      :managed_pipeline_mode   => 'Classic'
+      :managed_pipeline_mode   => 'Classic',
+      :apppool_recycle_schedule => %w(01:00:00 23:59:59)
     }}
 
     it { should contain_exec('Create-myAppPool.example.com').with(
@@ -61,6 +112,55 @@ describe 'iis::manage_app_pool', :type => :define do
       :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 1",
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Classic') -eq 0) { exit 1 } else { exit 0 }",)
     }
+
+    it { should contain_exec("App Pool Recycle Schedule - myAppPool.example.com - \"01:00:00\",\"23:59:59\"").with(
+      :command => "[string]\$ApplicationPoolName = \"myAppPool.example.com\";[string[]]\$RestartTimes = @(\"01:00:00\",\"23:59:59\");Import-Module WebAdministration;Clear-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule;\
+foreach (\$restartTime in \$RestartTimes){Write-Output \"Adding recycle at \$restartTime\";New-ItemProperty -Path \"IIS:\\AppPools\\\$ApplicationPoolName\" -Name Recycling.periodicRestart.schedule -Value @{value=\$restartTime};}",
+      :unless  => "[string]\$ApplicationPoolName = \"myAppPool.example.com\";[string[]]\$RestartTimes = @(\"01:00:00\",\"23:59:59\");Import-Module WebAdministration;[Collections.Generic.List[String]]\$collectionAsList = @();\
+for(\$i=0; \$i -lt (Get-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule.collection).Count; \$i++){\$collectionAsList.Add((Get-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule.collection)[\$i].value.ToString());}\
+if(\$collectionAsList.Count -ne \$RestartTimes.Length){exit 1;}foreach (\$restartTime in \$RestartTimes) {if(!\$collectionAsList.Contains(\$restartTime)){exit 1;}}exit 0;",)
+    }
+
+    it { should_not contain_exec(/CLEAR App Pool Recycle Schedule.*/) }
+  end
+
+  describe 'when managing the iis application pool - v2.0 Classic and clearing scheduled app pool recycling' do
+    let(:title) { 'myAppPool.example.com' }
+    let(:params) {{
+      :enable_32_bit           => true,
+      :managed_runtime_version => 'v2.0',
+      :managed_pipeline_mode   => 'Classic',
+      :apppool_recycle_schedule => []
+    }}
+
+    it { should contain_exec('Create-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; New-Item \"IIS:\\AppPools\\myAppPool.example.com\"",
+      :onlyif  => "Import-Module WebAdministration; if((Test-Path \"IIS:\\AppPools\\myAppPool.example.com\")) { exit 1 } else { exit 0 }",)
+    }
+
+    it { should contain_exec('Framework-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedRuntimeVersion v2.0",
+      :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedRuntimeVersion).Value.CompareTo(\'v2.0\') -eq 0) { exit 1 } else { exit 0 }",
+      :require => 'Exec[Create-myAppPool.example.com]',)
+    }
+
+    it { should contain_exec('32bit-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" enable32BitAppOnWin64 true",
+      :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" enable32BitAppOnWin64).Value -eq [System.Convert]::ToBoolean(\'true\')) { exit 1 } else { exit 0 }",
+      :require => 'Exec[Create-myAppPool.example.com]',)
+    }
+
+    it { should contain_exec('ManagedPipelineMode-myAppPool.example.com').with(
+      :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 1",
+      :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Classic') -eq 0) { exit 1 } else { exit 0 }",)
+    }
+
+    it { should contain_exec('CLEAR App Pool Recycle Schedule - myAppPool.example.com').with(
+      :command => "[string]\$ApplicationPoolName = \"myAppPool.example.com\";Import-Module WebAdministration;Write-Output \"removing scheduled recycles\";Clear-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule;",
+      :unless  => "[string]\$ApplicationPoolName = \"myAppPool.example.com\";Import-Module WebAdministration;if((Get-ItemProperty IIS:\\AppPools\\\$ApplicationPoolName -Name Recycling.periodicRestart.schedule.collection).Length -eq \$null){exit 0;}else{exit 1;}",)
+    }
+
+    it { should_not contain_exec(/App Pool Recycle Schedule.*/) }
   end
 
   describe 'when managing the iis application pool without passing parameters' do
@@ -87,6 +187,10 @@ describe 'iis::manage_app_pool', :type => :define do
       :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 0",
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Integrated') -eq 0) { exit 1 } else { exit 0 }",)
     }
+
+    it { should_not contain_exec(/App Pool Recycle Schedule.*/) }
+
+    it { should_not contain_exec(/CLEAR App Pool Recycle Schedule.*/) }
   end
 
   describe 'when managing the iis application with a managed_runtime_version of v2.0' do
@@ -100,6 +204,10 @@ describe 'iis::manage_app_pool', :type => :define do
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedRuntimeVersion).Value.CompareTo(\'v2.0\') -eq 0) { exit 1 } else { exit 0 }",
       :require => 'Exec[Create-myAppPool.example.com]',)
     }
+
+    it { should_not contain_exec(/App Pool Recycle Schedule.*/) }
+
+    it { should_not contain_exec(/CLEAR App Pool Recycle Schedule.*/) }
   end
 
   describe 'when managing the iis application with a managed_runtime_version of v4.0' do
@@ -113,6 +221,10 @@ describe 'iis::manage_app_pool', :type => :define do
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedRuntimeVersion).Value.CompareTo(\'v4.0\') -eq 0) { exit 1 } else { exit 0 }",
       :require => 'Exec[Create-myAppPool.example.com]',)
     }
+
+    it { should_not contain_exec(/App Pool Recycle Schedule.*/) }
+
+    it { should_not contain_exec(/CLEAR App Pool Recycle Schedule.*/) }
   end
 
   describe 'when managing the iis application with invalid managed_runtime_version parameter' do
@@ -136,6 +248,13 @@ describe 'iis::manage_app_pool', :type => :define do
     it { expect { should contain_exec('Create-myAppPool.example.com') }.to raise_error(Puppet::Error, /"false" is not a boolean\./) }
   end
 
+  describe 'when managing the iis application and apppool scheduled recycling value bad' do
+    let(:title) { 'myAppPool.example.com' }
+    let(:params) { { :apppool_recycle_schedule => %w(01:00 23:59:59) } }
+
+    it { expect { should contain_exec('Create-myAppPool.example.com') }.to raise_error(Puppet::Error, /01:00,23:59:59 bad - time format hh:mm:ss in array/) }
+  end
+
   describe 'when managing the iis application pool and setting ensure to present' do
     let(:title) { 'myAppPool.example.com' }
     let(:params) { { :ensure => 'present' } }
@@ -156,6 +275,10 @@ describe 'iis::manage_app_pool', :type => :define do
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" enable32BitAppOnWin64).Value -eq [System.Convert]::ToBoolean(\'false\')) { exit 1 } else { exit 0 }",
       :require => 'Exec[Create-myAppPool.example.com]',)
     }
+
+    it { should_not contain_exec(/App Pool Recycle Schedule.*/) }
+
+    it { should_not contain_exec(/CLEAR App Pool Recycle Schedule.*/) }
   end
 
   describe 'when managing the iis application pool and setting ensure to installed' do
@@ -183,6 +306,10 @@ describe 'iis::manage_app_pool', :type => :define do
       :command => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode 0",
       :onlyif  => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\myAppPool.example.com\" managedPipelineMode).CompareTo('Integrated') -eq 0) { exit 1 } else { exit 0 }",)
     }
+
+    it { should_not contain_exec(/App Pool Recycle Schedule.*/) }
+
+    it { should_not contain_exec(/CLEAR App Pool Recycle Schedule.*/) }
   end
 
   describe 'when managing the iis application pool and setting ensure to absent' do
@@ -199,6 +326,10 @@ describe 'iis::manage_app_pool', :type => :define do
     it { should_not contain_exec('32bit-myAppPool.example.com') }
 
     it { should_not contain_exec('ManagedPipelineMode-myAppPool.example.com') }
+
+    it { should_not contain_exec(/App Pool Recycle Schedule.*/) }
+
+    it { should_not contain_exec(/CLEAR App Pool Recycle Schedule.*/) }
   end
 
   describe 'when managing the iis application pool and setting ensure to purged' do
@@ -215,5 +346,9 @@ describe 'iis::manage_app_pool', :type => :define do
     it { should_not contain_exec('32bit-myAppPool.example.com') }
 
     it { should_not contain_exec('ManagedPipelineMode-myAppPool.example.com') }
+
+    it { should_not contain_exec(/App Pool Recycle Schedule.*/) }
+
+    it { should_not contain_exec(/CLEAR App Pool Recycle Schedule.*/) }
   end
 end


### PR DESCRIPTION
manage_app_pool - add scheduled recycling control

new param left undef default for backward compatibility
logic in class handles undef

caller provide array of time strings ['hh:mm:ss','...'] - empty array to
clear scheduled recycling on an app pool