### PR TITLE
Added site_id and related logic, testing, and documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Examples
 
         iis::manage_site {'www.mysite.com':
           site_path     => 'C:\inetpub\wwwroot\mysite',
+          site_id       => '10'
           port          => '80',
           ip_address    => '*',
           host_header   => 'www.mysite.com',

--- a/manifests/features/application_deployment.pp
+++ b/manifests/features/application_deployment.pp
@@ -1,7 +1,7 @@
 class iis::features::application_deployment {
 
   case $::kernelmajversion {
-    '6.2','6.3': {
+    '6.0','6.1': {
       ensure_resource('windowsfeature', 'IIS-ASPNET' )
       ensure_resource('windowsfeature', 'IIS-ASPNET45' )
       ensure_resource('windowsfeature', 'IIS-NetFxExtensibility' )
@@ -9,7 +9,7 @@ class iis::features::application_deployment {
       ensure_resource('windowsfeature', 'IIS-ISAPIExtentions' )
       ensure_resource('windowsfeature', 'IIS-ISAPIFilter' )
     }
-    '6.0','6.1': {
+    '6.2','6.3': {
       ensure_resource('windowsfeature', 'Web-Asp-Net' )
       ensure_resource('windowsfeature', 'Web-Net-Ext' )
       ensure_resource('windowsfeature', 'Web-ISAPI-Ext' )

--- a/manifests/features/common_http.pp
+++ b/manifests/features/common_http.pp
@@ -1,12 +1,12 @@
 class iis::features::common_http {
 
   case $::kernelmajversion {
-    '6.2','6.3': {
+    '6.0','6.1': {
       ensure_resource('windowsfeature', 'IIS-StaticContent' )
       ensure_resource('windowsfeature', 'IIS-HttpErrors' )
       ensure_resource('windowsfeature', 'IIS-DefaultDocument' )
     }
-    '6.0','6.1': {
+    '6.2','6.3': {
       ensure_resource('windowsfeature', 'Web-Static-Content' )
       ensure_resource('windowsfeature', 'Web-Http-Errors' )
       ensure_resource('windowsfeature', 'Web-Default-Doc' )

--- a/manifests/features/health_and_diagnostics.pp
+++ b/manifests/features/health_and_diagnostics.pp
@@ -1,11 +1,11 @@
 class iis::features::health_and_diagnostics {
 
   case $::kernelmajversion {
-    '6.2','6.3': {
+    '6.0','6.1': {
       ensure_resource('windowsfeature', 'IIS-HttpLogging' )
       ensure_resource('windowsfeature', 'IIS-RequestMonitor' )
     }
-    '6.0','6.1': {
+    '6.2','6.3': {
       ensure_resource('windowsfeature', 'Web-Http-Logging' )
       ensure_resource('windowsfeature', 'Web-Request-Monitor' )
     }

--- a/manifests/features/management_tools.pp
+++ b/manifests/features/management_tools.pp
@@ -1,11 +1,11 @@
 class iis::features::management_tools {
 
   case $::kernelmajversion {
-    '6.2','6.3': {
+    '6.0','6.1': {
       ensure_resource('windowsfeature', 'IIS-WebServerManagementTools' )
       ensure_resource('windowsfeature', 'IIS-ManagementConsole' )
     }
-    '6.0','6.1': {
+    '6.2','6.3': {
       ensure_resource('windowsfeature', 'Web-Mgmt-Tools' )
       ensure_resource('windowsfeature', 'Web-Mgmt-Console' )
     }

--- a/manifests/features/performance.pp
+++ b/manifests/features/performance.pp
@@ -1,11 +1,11 @@
 class iis::features::performance {
 
   case $::kernelmajversion {
-    '6.2','6.3': {
+    '6.0','6.1': {
       ensure_resource('windowsfeature', 'IIS-HttpCompressionStatic' )
       ensure_resource('windowsfeature', 'IIS-HttpCompressionDynamic' )
     }
-    '6.0','6.1': {
+    '6.2','6.3': {
       ensure_resource('windowsfeature', 'Web-Stat-Compression' )
       ensure_resource('windowsfeature', 'Web-Dyn-Compression' )
     }

--- a/manifests/features/security.pp
+++ b/manifests/features/security.pp
@@ -1,10 +1,10 @@
 class iis::features::security {
 
   case $::kernelmajversion {
-    '6.2','6.3': {
+    '6.0','6.1': {
       ensure_resource('windowsfeature', 'IIS-RequestFiltering' )
     }
-    '6.0','6.1': {
+    '6.2','6.3': {
       ensure_resource('windowsfeature', 'Web-Filtering' )
     }
     default: {

--- a/manifests/manage_site.pp
+++ b/manifests/manage_site.pp
@@ -3,6 +3,7 @@ define iis::manage_site(
   $ensure      = 'present',
   $site_name   = $title,
   $site_path   = '',
+  $site_id     = '',
   $app_pool    = '',
   $host_header = '',
   $ip_address  = '*',
@@ -30,7 +31,7 @@ define iis::manage_site(
 
     $switches = join($create_switches,' ')
     exec { "CreateSite-${site_name}" :
-      command   => "Import-Module WebAdministration; \$id = (Get-WebSite | foreach {\$_.id} | sort -Descending | select -first 1) + 1; New-WebSite ${switches} -ID \$id",
+      command   => "Import-Module WebAdministration; \$id = \'${site_id}\'; if (\$id) {Get-WebSite | foreach { if (\$_.id -match \$id) { exit 1 }}} else {\$id = (Get-WebSite | foreach {\$_.id} | sort -Descending | select -first 1) + 1}; New-WebSite ${switches} -ID \$id",
       onlyif    => "Import-Module WebAdministration; if((${$cmd_site_exists})) { exit 1 } else { exit 0 }",
       provider  => 'powershell',
       path      => $::path,

--- a/spec/defines/manage_site_spec.rb
+++ b/spec/defines/manage_site_spec.rb
@@ -13,7 +13,8 @@ describe 'iis::manage_site', type: :define do
     }}
 
     it { should contain_exec('CreateSite-myWebSite').with(
-      'command' => 'Import-Module WebAdministration; $id = (Get-WebSite | foreach {$_.id} | sort -Descending | select -first 1) + 1; New-WebSite -Name "myWebSite" -Port 80 -IP * -HostHeader "myHost.example.com" -PhysicalPath "C:\\inetpub\\wwwroot\\myWebSite" -ApplicationPool "myAppPool.example.com" -Ssl:$false -ID $id',
+      'command' => 'Import-Module WebAdministration; $id = \'\'; if ($id) {Get-WebSite | foreach { if ($_.id -match $id) { exit 1 }}} else {$id = (Get-WebSite | foreach {$_.id} | sort -Descending | select -first 1) + 1}; '\
+                   'New-WebSite -Name "myWebSite" -Port 80 -IP * -HostHeader "myHost.example.com" -PhysicalPath "C:\\inetpub\\wwwroot\\myWebSite" -ApplicationPool "myAppPool.example.com" -Ssl:$false -ID $id',
       'onlyif'  => 'Import-Module WebAdministration; if((Test-Path "IIS:\\Sites\\myWebSite")) { exit 1 } else { exit 0 }',)
     }
 
@@ -34,6 +35,7 @@ describe 'iis::manage_site', type: :define do
       app_pool: 'myAppPool.example.com',
       host_header: 'myHost.example.com',
       site_path: 'C:\inetpub\wwwroot\path',
+      site_id: '10',
       port: '1080',
       ip_address: '127.0.0.1',
       ensure: 'present'
@@ -43,7 +45,8 @@ describe 'iis::manage_site', type: :define do
     }}
 
     it { should contain_exec('CreateSite-myWebSite').with(
-      'command' => 'Import-Module WebAdministration; $id = (Get-WebSite | foreach {$_.id} | sort -Descending | select -first 1) + 1; New-WebSite -Name "myWebSite" -Port 1080 -IP 127.0.0.1 -HostHeader "myHost.example.com" -PhysicalPath "C:\\inetpub\\wwwroot\\path" -ApplicationPool "myAppPool.example.com" -Ssl:$false -ID $id',
+      'command' => 'Import-Module WebAdministration; $id = \'10\'; if ($id) {Get-WebSite | foreach { if ($_.id -match $id) { exit 1 }}} else {$id = (Get-WebSite | foreach {$_.id} | sort -Descending | select -first 1) + 1}; '\
+                   'New-WebSite -Name "myWebSite" -Port 1080 -IP 127.0.0.1 -HostHeader "myHost.example.com" -PhysicalPath "C:\\inetpub\\wwwroot\\path" -ApplicationPool "myAppPool.example.com" -Ssl:$false -ID $id',
       'onlyif'  => 'Import-Module WebAdministration; if((Test-Path "IIS:\\Sites\\myWebSite")) { exit 1 } else { exit 0 }',)
     }
 
@@ -64,6 +67,7 @@ describe 'iis::manage_site', type: :define do
       app_pool: 'myAppPool.example.com',
       host_header: 'myHost.example.com',
       site_path: 'C:\inetpub\wwwroot\myWebSite',
+      site_id: '20',
       ensure: 'present'
     } }
     let(:facts) {{
@@ -71,7 +75,8 @@ describe 'iis::manage_site', type: :define do
     }}
 
     it { should contain_exec('CreateSite-myWebSite').with(
-      'command' => 'Import-Module WebAdministration; $id = (Get-WebSite | foreach {$_.id} | sort -Descending | select -first 1) + 1; New-WebSite -Name "myWebSite" -Port 80 -IP * -HostHeader "myHost.example.com" -PhysicalPath "C:\\inetpub\\wwwroot\\myWebSite" -ApplicationPool "myAppPool.example.com" -Ssl:$false -ID $id',
+      'command' => 'Import-Module WebAdministration; $id = \'20\'; if ($id) {Get-WebSite | foreach { if ($_.id -match $id) { exit 1 }}} else {$id = (Get-WebSite | foreach {$_.id} | sort -Descending | select -first 1) + 1}; '\
+                   'New-WebSite -Name "myWebSite" -Port 80 -IP * -HostHeader "myHost.example.com" -PhysicalPath "C:\\inetpub\\wwwroot\\myWebSite" -ApplicationPool "myAppPool.example.com" -Ssl:$false -ID $id',
       'onlyif'  => 'Import-Module WebAdministration; if((Test-Path "IIS:\\Sites\\myWebSite")) { exit 1 } else { exit 0 }',)
     }
 
@@ -92,6 +97,7 @@ describe 'iis::manage_site', type: :define do
       app_pool: 'myAppPool.example.com',
       host_header: 'myHost.example.com',
       site_path: 'C:\inetpub\wwwroot\myWebSite',
+      site_id: '30',
       ensure: 'installed'
     } }
     let(:facts) {{
@@ -99,7 +105,8 @@ describe 'iis::manage_site', type: :define do
     }}
 
     it { should contain_exec('CreateSite-myWebSite').with(
-      'command' => 'Import-Module WebAdministration; $id = (Get-WebSite | foreach {$_.id} | sort -Descending | select -first 1) + 1; New-WebSite -Name "myWebSite" -Port 80 -IP * -HostHeader "myHost.example.com" -PhysicalPath "C:\\inetpub\\wwwroot\\myWebSite" -ApplicationPool "myAppPool.example.com" -Ssl:$false -ID $id',
+      'command' => 'Import-Module WebAdministration; $id = \'30\'; if ($id) {Get-WebSite | foreach { if ($_.id -match $id) { exit 1 }}} else {$id = (Get-WebSite | foreach {$_.id} | sort -Descending | select -first 1) + 1}; '\
+                   'New-WebSite -Name "myWebSite" -Port 80 -IP * -HostHeader "myHost.example.com" -PhysicalPath "C:\\inetpub\\wwwroot\\myWebSite" -ApplicationPool "myAppPool.example.com" -Ssl:$false -ID $id',
       'onlyif'  => 'Import-Module WebAdministration; if((Test-Path "IIS:\\Sites\\myWebSite")) { exit 1 } else { exit 0 }',)
     }
 


### PR DESCRIPTION
Had to recreate my repo due to irrecoverable conflicts.

Our organization uses the site ID of each web service for logging sanity and have a need to have this set. I added the variable and the logic to add one if not supplied and verify it isn't in use.

Also, during my usage, while attempting to use the installation mechanic, I found the versions listed in the .pp files were reversed. IIS-* is used in WS2008/R2 and Web-* in WS2012/R2, not the other way around. Tested locally and works in our infrastructure.