### PR TITLE
Adding spec for `iis_version` fact

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development do
   gem 'travis',       :require => false
   gem 'travis-lint',  :require => false
   gem 'guard-rake',   :require => false
+  gem 'listen', '<= 3.0.6', :require => false
 end
 
 group :system_tests do

--- a/lib/facter/iis_version.rb
+++ b/lib/facter/iis_version.rb
@@ -1,16 +1,13 @@
+require 'facter/util/registryiis'
+
 Facter.add(:iis_version) do
   confine kernel: :windows
   setcode do
-    version = nil
-    require 'win32/registry'
-    begin
-      Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Microsoft\InetStp') do |reg|
-        version = reg['VersionString']
-        version = version[8..-1]
-      end
-    rescue Win32::Registry::Error
-      nil
-    end
-    version
+    iis_version_string = Facter::Util::Registryiis.iis_version_string_from_registry
+    # String returned on:
+    # Windows 2012 R2 - "Version 8.5"
+    # Windows 2008 R2 - "Version 7.5"
+    # Lets gsub to get just the number
+    iis_version_string.gsub(/Version\s+/, '') unless iis_version_string.nil?
   end
 end

--- a/lib/facter/util/registryiis.rb
+++ b/lib/facter/util/registryiis.rb
@@ -1,0 +1,10 @@
+module Facter::Util::Registryiis
+  def self.iis_version_string_from_registry
+    require 'win32/registry'
+    Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Microsoft\InetStp')['VersionString']
+  rescue Win32::Registry::Error => e
+    Facter.debug "Accessing SOFTWARE\\Microsoft\\InetStp gave an error: #{e}"
+    Facter.debug 'IIS is probably not installed'
+    nil
+  end
+end

--- a/spec/unit/facter/iis_version_spec.rb
+++ b/spec/unit/facter/iis_version_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'facter/util/registryiis'
+
+describe Facter::Util::Fact do
+  before {
+    Facter.clear
+  }
+
+  describe 'Windows' do
+    context 'returns IIS version when avaliable' do
+      before do
+        Facter.fact(:kernel).stubs(:value).returns('Windows')
+        Facter::Util::Resolution.stubs(:exec)
+        Facter::Util::Registryiis.stubs(:iis_version_string_from_registry).returns('Version 8.5')
+      end
+      let(:facts) { { kernel: 'Windows' } }
+      it do
+        expect(Facter.value(:iis_version)).to eq('8.5')
+      end
+    end
+
+    context 'returns nil when IIS version no avaliable' do
+      before do
+        Facter.fact(:kernel).stubs(:value).returns('Windows')
+        Facter::Util::Resolution.stubs(:exec)
+        Facter::Util::Registryiis.stubs(:iis_version_string_from_registry).returns(nil)
+      end
+      let(:facts) { { kernel: 'Windows' } }
+      it do
+        expect(Facter.value(:iis_version)).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Simplifying registry logic (don't need block, can just access directly)
* `(version[8..-1] is not super intiutive
* Changing to gsub to make more readable `gsub(/Version\s+/,'')`
* Moving registry logic to util class to make mocking easier
* Adding spec, mocking the logic from the util class