### PR TITLE
Make the fact work on RHEL6 systems

### DIFF
--- a/lib/facter/iis_version.rb
+++ b/lib/facter/iis_version.rb
@@ -1,7 +1,7 @@
 require 'facter/util/registryiis'
 
 Facter.add(:iis_version) do
-  confine kernel: :windows
+  confine :kernel => :windows
   setcode do
     iis_version_string = Facter::Util::Registryiis.iis_version_string_from_registry
     # String returned on:

--- a/lib/facter/iis_version.rb
+++ b/lib/facter/iis_version.rb
@@ -1,8 +1,7 @@
 require 'facter/util/registryiis'
 
 Facter.add(:iis_version) do
-  # rubocop:disable Style/HashSyntax
-  confine :kernel => :windows
+  confine :kernel => :windows # rubocop:disable Style/HashSyntax
   setcode do
     iis_version_string = Facter::Util::Registryiis.iis_version_string_from_registry
     # String returned on:

--- a/lib/facter/iis_version.rb
+++ b/lib/facter/iis_version.rb
@@ -1,6 +1,7 @@
 require 'facter/util/registryiis'
 
 Facter.add(:iis_version) do
+  # rubocop:disable Style/HashSyntax
   confine :kernel => :windows
   setcode do
     iis_version_string = Facter::Util::Registryiis.iis_version_string_from_registry


### PR DESCRIPTION
In our combined Windows/Linux environment, running puppet 3.8.7, we got this error:

Error loading fact /var/lib/puppet/lib/facter/iis_version.rb: /var/lib/puppet/lib/facter/iis_version.rb:2: syntax error, unexpected ':', expecting kEND
  confine kernel: :windows

Using the 'former' syntax makes the fact work again.