### PR TITLE
Updates spec to silence warning

### DIFF
--- a/spec/unit/puppet/type/iis_application_spec.rb
+++ b/spec/unit/puppet/type/iis_application_spec.rb
@@ -36,7 +36,7 @@ describe Puppet::Type.type(:iis_application) do
       expect(subject(params.merge(path: 'C:\Temp'))[:path]).to eq('C:\Temp')
     end
     it 'should reject network' do
-      expect { subject(params.merge(path: '//remote/Temp'))[:path] }.to raise_error
+      expect { subject(params.merge(path: '//remote/Temp'))[:path] }.to raise_error(Puppet::ResourceError)
     end
   end
 


### PR DESCRIPTION
```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<Puppet::ResourceError: Parameter path failed on Iis_application[test_application]: Validate method failed for class path: File paths must be fully qualified, not '//remote/Temp'>. Instead consider providing a specific error class or message. This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. Called from /Users/petersouter/projects/voxpupuli-iis/spec/unit/puppet/type/iis_application_spec.rb:39:in `block (3 levels) in <top (required)>'.
```