### PR TITLE
Fixed a casing issue

### DIFF
--- a/manifests/manage_app_pool.pp
+++ b/manifests/manage_app_pool.pp
@@ -159,12 +159,12 @@ define iis::manage_app_pool (
     }
     
     
-    if $apppool_idle_timeout_action {
+    if $apppool_idle_timeout_action != undef {
       validate_re($apppool_idle_timeout_action, '^(Suspend|Terminate)$')
       exec { "IdleTimeoutAction-${app_pool_name}":
-        command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" processmodel.idletimeoutaction ${apppool_idle_timeout_action}",
+        command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" processmodel.idleTimeoutAction ${apppool_idle_timeout_action}",
         provider  => powershell,
-        onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" processmodel.idletimeoutaction).CompareTo('${apppool_idle_timeout_action}') -eq 0) { exit 1 } else { exit 0 }",
+        onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" processmodel.idleTimeoutAction).CompareTo('${apppool_idle_timeout_action}') -eq 0) { exit 1 } else { exit 0 }",
         require   => Exec["Create-${app_pool_name}"],
         logoutput => true,
       }

--- a/manifests/manage_app_pool.pp
+++ b/manifests/manage_app_pool.pp
@@ -160,11 +160,11 @@ define iis::manage_app_pool (
     
     
     if $apppool_idle_timeout_action {
-      validate_re($apppool_idle_Timeout_action, '^(Suspend|Terminate)$')
+      validate_re($apppool_idle_timeout_action, '^(Suspend|Terminate)$')
       exec { "IdleTimeoutAction-${app_pool_name}":
-        command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode ${apppool_idle_Timeout_action}",
+        command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode ${apppool_idle_timeout_action}",
         provider  => powershell,
-        onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode).CompareTo('${apppool_idle_Timeout_action}') -eq 0) { exit 1 } else { exit 0 }",
+        onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode).CompareTo('${apppool_idle_timeout_action}') -eq 0) { exit 1 } else { exit 0 }",
         require   => Exec["Create-${app_pool_name}"],
         logoutput => true,
       }

--- a/manifests/manage_app_pool.pp
+++ b/manifests/manage_app_pool.pp
@@ -23,7 +23,6 @@ define iis::manage_app_pool (
   validate_re($managed_pipeline_mode, ['^(Integrated|Classic)$'])
   validate_re($ensure, '^(present|installed|absent|purged)$', 'ensure must be one of \'present\', \'installed\', \'absent\', \'purged\'')
   validate_re($start_mode, '^(OnDemand|AlwaysRunning)$')
-  validate_re($apppool_idle_Timeout_action, '^(Suspend|Terminate)$')
   validate_bool($rapid_fail_protection)
 
   if $apppool_idle_timeout_minutes != undef {
@@ -159,6 +158,9 @@ define iis::manage_app_pool (
       logoutput => true,
     }
     
+    
+if $apppool_idle_Timeout_action {
+    validate_re($apppool_idle_Timeout_action, '^(Suspend|Terminate)$')
     exec { "IdleTimeoutAction-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode ${apppool_idle_Timeout_action}",
       provider  => powershell,
@@ -166,6 +168,7 @@ define iis::manage_app_pool (
       require   => Exec["Create-${app_pool_name}"],
       logoutput => true,
     }
+  }
 
     exec { "RapidFailProtection-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" failure.rapidFailProtection ${rapid_fail_protection}",

--- a/manifests/manage_app_pool.pp
+++ b/manifests/manage_app_pool.pp
@@ -15,7 +15,7 @@ define iis::manage_app_pool (
   $apppool_recycle_periodic_minutes = undef,
   $apppool_recycle_schedule         = undef,
   $apppool_recycle_logging          = undef,
-  $apppool_idle_Timeout_action      = undef,
+  $apppool_idle_timeout_action      = undef
 ) {
 
   validate_bool($enable_32_bit)
@@ -159,16 +159,16 @@ define iis::manage_app_pool (
     }
     
     
-if $apppool_idle_Timeout_action {
-    validate_re($apppool_idle_Timeout_action, '^(Suspend|Terminate)$')
-    exec { "IdleTimeoutAction-${app_pool_name}":
-      command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode ${apppool_idle_Timeout_action}",
-      provider  => powershell,
-      onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode).CompareTo('${apppool_idle_Timeout_action}') -eq 0) { exit 1 } else { exit 0 }",
-      require   => Exec["Create-${app_pool_name}"],
-      logoutput => true,
+    if $apppool_idle_timeout_action {
+      validate_re($apppool_idle_Timeout_action, '^(Suspend|Terminate)$')
+      exec { "IdleTimeoutAction-${app_pool_name}":
+        command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode ${apppool_idle_Timeout_action}",
+        provider  => powershell,
+        onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode).CompareTo('${apppool_idle_Timeout_action}') -eq 0) { exit 1 } else { exit 0 }",
+        require   => Exec["Create-${app_pool_name}"],
+        logoutput => true,
+      }
     }
-  }
 
     exec { "RapidFailProtection-${app_pool_name}":
       command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" failure.rapidFailProtection ${rapid_fail_protection}",

--- a/manifests/manage_app_pool.pp
+++ b/manifests/manage_app_pool.pp
@@ -15,7 +15,7 @@ define iis::manage_app_pool (
   $apppool_recycle_periodic_minutes = undef,
   $apppool_recycle_schedule         = undef,
   $apppool_recycle_logging          = undef,
-  $apppool_idle_Timeout_action      = 'Terminate'
+  $apppool_idle_Timeout_action      = undef,
 ) {
 
   validate_bool($enable_32_bit)

--- a/manifests/manage_app_pool.pp
+++ b/manifests/manage_app_pool.pp
@@ -162,9 +162,9 @@ define iis::manage_app_pool (
     if $apppool_idle_timeout_action {
       validate_re($apppool_idle_timeout_action, '^(Suspend|Terminate)$')
       exec { "IdleTimeoutAction-${app_pool_name}":
-        command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode ${apppool_idle_timeout_action}",
+        command   => "Import-Module WebAdministration; Set-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" processmodel.idletimeoutaction ${apppool_idle_timeout_action}",
         provider  => powershell,
-        onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" startMode).CompareTo('${apppool_idle_timeout_action}') -eq 0) { exit 1 } else { exit 0 }",
+        onlyif    => "Import-Module WebAdministration; if((Get-ItemProperty \"IIS:\\AppPools\\${app_pool_name}\" processmodel.idletimeoutaction).CompareTo('${apppool_idle_timeout_action}') -eq 0) { exit 1 } else { exit 0 }",
         require   => Exec["Create-${app_pool_name}"],
         logoutput => true,
       }


### PR DESCRIPTION
Previously I have processmodel.idletimeoutaction and it was always trying to apply my changes when it saw a difference but it would never actually make the change.  I finally noticed that casing matters and it needs to be processmodel.idleTimeoutAction.  I corrected that as well as also added the check to test to see if the value was NOT undefined.

if $apppool_idle_timeout_action != undef