### PR TITLE
Revert metadata.json license back to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2014 OpenTable, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "puppet-iis",
   "version": "2.0.3-rc0",
   "author": "voxpupuli",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "summary": "Module that will manage IIS for windows server 2008 and above. It will help maintain application pools, sites and virtual applications",
   "source": "https://github.com/voxpupuli/puppet-iis.git",
   "project_page": "https://github.com/voxpupuli/puppet-iis",


### PR DESCRIPTION
Relicensing can only be done with the permission of all the copyright
holders.