### PR TITLE
Unmanage Gemfile in .sync.yml

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,15 +1,5 @@
 ---
 Gemfile:
-  supports_windows: true
-  required:
-    ':system_tests':
-      - gem: beaker
-        version: '2.43.0'
-      - gem: beaker-rspec
-        version: '5.3.0'
-      - gem: winrm
-        version: '1.8.1'
-      - gem: beaker-puppet_install_helper
 #spec/spec_helper_acceptance.rb:
 # Temporarily unmanage spec_helper_acceptance (iss. #133)
 #  windows: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,5 +1,4 @@
 ---
-Gemfile:
 #spec/spec_helper_acceptance.rb:
 # Temporarily unmanage spec_helper_acceptance (iss. #133)
 #  windows: true


### PR DESCRIPTION
.sync.yml was managing gemfile and squashing gems we needed to run spec tests. 