### PR TITLE
Prepare for version 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+#2016-06-29
+##Summary
+
+  Major IIS site improvements; bug fixes.
+
+###Features
+  - Add idle action timeout
+  - Add state to site for Started or Stopped
+
+###Improvements
+  - Overhaul of IIS site logic. Server 2008 support dropped.
+  - Add host_header functionality
+  - Add refresh event to iis_site
+
+###Bugfixes
+  - Fix error thrown by ConverTo-Json
+  - Fix fact causing errors on RHEL6 nodes
+  - Remove invalid argument -SslFlags from Remove-WebBinding
+
 #2016-04-12 - Release 2.0.2
 ###Summary
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-iis",
-  "version": "2.0.3-rc0",
+  "version": "3.0.0",
   "author": "voxpupuli",
   "license": "Apache-2.0",
   "summary": "Module that will manage IIS for windows server 2008 and above. It will help maintain application pools, sites and virtual applications",
@@ -11,7 +11,6 @@
     {
       "operatingsystem": "windows",
       "operatingsystemrelease": [
-        "2008R2",
         "2012",
         "2012R2"
       ]


### PR DESCRIPTION
The big thing in this version is a refactor of IIS sites and ending support for server 2008. 

Per @igalic's suggestion, we should wait for input from @WhatsARanjit for confirmation before releasing.
