### PR TITLE
Adding support for Windows 10.0 in `manifests/features`

### DIFF
--- a/manifests/features/application_deployment.pp
+++ b/manifests/features/application_deployment.pp
@@ -9,7 +9,7 @@ class iis::features::application_deployment {
       ensure_resource('windowsfeature', 'IIS-ISAPIExtentions' )
       ensure_resource('windowsfeature', 'IIS-ISAPIFilter' )
     }
-    '6.2','6.3': {
+    '6.2','6.3','10.0': {
       ensure_resource('windowsfeature', 'Web-Asp-Net' )
       ensure_resource('windowsfeature', 'Web-Net-Ext' )
       ensure_resource('windowsfeature', 'Web-ISAPI-Ext' )

--- a/manifests/features/common_http.pp
+++ b/manifests/features/common_http.pp
@@ -6,7 +6,7 @@ class iis::features::common_http {
       ensure_resource('windowsfeature', 'IIS-HttpErrors' )
       ensure_resource('windowsfeature', 'IIS-DefaultDocument' )
     }
-    '6.2','6.3': {
+    '6.2','6.3','10.0': {
       ensure_resource('windowsfeature', 'Web-Static-Content' )
       ensure_resource('windowsfeature', 'Web-Http-Errors' )
       ensure_resource('windowsfeature', 'Web-Default-Doc' )

--- a/manifests/features/health_and_diagnostics.pp
+++ b/manifests/features/health_and_diagnostics.pp
@@ -5,7 +5,7 @@ class iis::features::health_and_diagnostics {
       ensure_resource('windowsfeature', 'IIS-HttpLogging' )
       ensure_resource('windowsfeature', 'IIS-RequestMonitor' )
     }
-    '6.2','6.3': {
+    '6.2','6.3','10.0': {
       ensure_resource('windowsfeature', 'Web-Http-Logging' )
       ensure_resource('windowsfeature', 'Web-Request-Monitor' )
     }

--- a/manifests/features/management_tools.pp
+++ b/manifests/features/management_tools.pp
@@ -5,7 +5,7 @@ class iis::features::management_tools {
       ensure_resource('windowsfeature', 'IIS-WebServerManagementTools' )
       ensure_resource('windowsfeature', 'IIS-ManagementConsole' )
     }
-    '6.2','6.3': {
+    '6.2','6.3','10.0': {
       ensure_resource('windowsfeature', 'Web-Mgmt-Tools' )
       ensure_resource('windowsfeature', 'Web-Mgmt-Console' )
     }

--- a/manifests/features/performance.pp
+++ b/manifests/features/performance.pp
@@ -5,7 +5,7 @@ class iis::features::performance {
       ensure_resource('windowsfeature', 'IIS-HttpCompressionStatic' )
       ensure_resource('windowsfeature', 'IIS-HttpCompressionDynamic' )
     }
-    '6.2','6.3': {
+    '6.2','6.3','10.0': {
       ensure_resource('windowsfeature', 'Web-Stat-Compression' )
       ensure_resource('windowsfeature', 'Web-Dyn-Compression' )
     }

--- a/manifests/features/security.pp
+++ b/manifests/features/security.pp
@@ -4,7 +4,7 @@ class iis::features::security {
     '6.0','6.1': {
       ensure_resource('windowsfeature', 'IIS-RequestFiltering' )
     }
-    '6.2','6.3': {
+    '6.2','6.3','10.0': {
       ensure_resource('windowsfeature', 'Web-Filtering' )
     }
     default: {


### PR DESCRIPTION
Windows 10.0 supports all of the following WindowsFeatures:

- Web-Static-Content
- Web-Http-Errors
- Web-Default-Doc
- Web-Http-Logging
- Web-Request-Monitor
- Web-Mgmt-Tools
- Web-Mgmt-Console
- Web-Stat-Compression
- Web-Dyn-Compression
- Web-Filtering