### PR TITLE
Bump min version_requirement for Puppet + deps

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,12 +19,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
-    {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.8.7 < 5.0.0"
     }
   ],
   "dependencies": [
@@ -34,7 +30,7 @@
     },
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">= 1.0.1 < 2.0.0"
+      "version_requirement": ">= 1.1.1 < 3.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata

Also remove deprecated pe version_requirement field