### PR TITLE
Release 3.1.0 for deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+# 2017-06-13 Release 3.1.0
+
+## Summary
+
+  Release designating the deprecation of puppet-iis for the migration to
+  puppetlabs-iis.  The puppetlabs-iis 4.0.0 series continues the functionality
+  present in the 3.x puppet-iis series along with lots of additional bugfixes,
+  expanded functionality, improved performance, and official support from
+  Puppet.
+
+### Improvements
+
+- Add notification and documentation for namespace migration.
+
 # 2017-02-11 Release 3.0.0
 
 ## Summary
@@ -181,6 +195,7 @@
 - removed validation around wildcard '*' for IP address binding
 
 ## 2013-08-22 - Release 0.0.1
- ### Summary
+
+### Summary
 
    Initial version

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Deprecation notice
+
+This module has been moved to the care of Puppet, where it is now being maintained and updated. Find new versions at https://forge.puppet.com/puppetlabs/iis .
+
+Details for migrating can be found at: https://github.com/puppetlabs/puppetlabs-iis/blob/master/MIGRATION.md
+
 # IIS module for Puppet
 
 [![Build Status](https://travis-ci.org/voxpupuli/puppet-iis.png?branch=master)](https://travis-ci.org/voxpupuli/puppet-iis)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,5 @@
 class iis {
+  warning('puppet-iis is now deprecated. Please use puppetlabs-iis instead')
   include ::iis::features::application_deployment
   include ::iis::features::common_http
   include ::iis::features::health_and_diagnostics

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-iis",
-  "version": "4.0.0-rc0",
+  "version": "3.1.0",
   "author": "Vox Pupuli",
   "license": "MIT",
   "summary": "Module that will manage IIS for windows server 2008 and above. It will help maintain application pools, sites and virtual applications",
@@ -19,7 +19,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.6.1 < 5.0.0"
+      "version_requirement": ">= 3.8.7 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
http://forge.puppet.com/puppetlabs/iis/4.0.0 is live and ships in the 5.0.0 of the windows pack: https://forge.puppet.com/puppetlabs/windows/5.0.0

The previously released version is 3.0.0, though the metadata was bumped to 4.0.0-rc0.

We can either do a 3.1.0 or a 99.99.99 as per https://voxpupuli.org/docs/#migrating-a-module-to-voxpupuli
