### PR TITLE
Remove bad spaces from README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ virtual applications with IIS 7 and above.
 #### Table of Contents
 
 1. [Overview](#overview)
-1. [Requirements] (#requirements)
-1. [Types] (#types)
-  * [iis_site] (#iis_site)
-  * [iis_pool] (#iis_pool)
-  * [iis_virtualdirectory] (#iis_virtualdirectory)
-  * [iis_application] (#iis_application)
+1. [Requirements](#requirements)
+1. [Types](#types)
+  * [iis_site](#iis_site)
+  * [iis_pool](#iis_pool)
+  * [iis_virtualdirectory](#iis_virtualdirectory)
+  * [iis_application](#iis_application)
 
 ## Overview
 


### PR DESCRIPTION
A link text and link URL should not be separated by whitespace - that breaks rendering. Instead, they should be together and then GitHub will properly present the link as a link instead of splitting it up.